### PR TITLE
Add GitHub Actions for Build and Release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,44 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        goos: [linux, darwin]
+        goarch: [amd64, arm64]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Go environment
+        uses: actions/setup-go@v5.0.0
+        with:
+          go-version: stable
+
+      - name: Build
+        env:
+          CGO_ENABLED: 0
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          GOOS=$GOOS GOARCH=$GOARCH go build -trimpath -o build/ ./cmd/cli/raiden.go
+          cd build
+          if [[ $GOOS == 'darwin' ]]; then
+            tar cvf raiden-macos-"$GOARCH".tar.gz raiden
+          else
+            tar cvf raiden-"$GOOS"-"$GOARCH".tar.gz raiden
+          fi
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: build/raiden-*
+          make_latest: true
+          generate_release_notes: true


### PR DESCRIPTION
This PR will enable workflows to build and release. Each time the commit get a tag with `v` prefix (e.g `v1.0.2`) it will trigger GitHub Actions to publish a release to "GitHub Release" https://github.com/sev-2/raiden/releases.
