### PR TITLE
fix: replace naming of default controller and server host

### DIFF
--- a/pkg/cli/configure/command.go
+++ b/pkg/cli/configure/command.go
@@ -76,7 +76,7 @@ func SimpleConfigure() (*Config, error) {
 			BreakerEnable: true,
 			TraceEnable:   false,
 			Version:       "1.0.0",
-			ServerHost:    "127.0.01",
+			ServerHost:    "127.0.0.1",
 			ServerPort:    "8002",
 		},
 	}

--- a/pkg/cli/generate/command.go
+++ b/pkg/cli/generate/command.go
@@ -111,12 +111,12 @@ func Run(flags *Flags, config *raiden.Config, projectPath string, initialize boo
 			GenerateLogger.Debug("start generate routes")
 			if initialize {
 				// generate example controller
-				GenerateLogger.Info("start generate hello word controller")
-				if err := generator.GenerateHelloWordController(projectPath, generator.Generate); err != nil {
+				GenerateLogger.Info("start generate hello world controller")
+				if err := generator.GenerateHelloWorldController(projectPath, generator.Generate); err != nil {
 					errChan <- err
 					return
 				}
-				GenerateLogger.Info("finish generate hello word controller")
+				GenerateLogger.Info("finish generate hello world controller")
 			}
 
 			// generate route base on controllers

--- a/pkg/generator/config.go
+++ b/pkg/generator/config.go
@@ -60,7 +60,7 @@ func GenerateConfig(basePath string, config *raiden.Config, generateFn GenerateF
 	filePath := filepath.Join(configPath, fmt.Sprintf("%s.%s", ConfigFile, "yaml"))
 
 	if config.ServerHost == "" {
-		config.ServerHost = "127.0.01"
+		config.ServerHost = "127.0.0.1"
 	}
 
 	if config.ServerPort == "" {

--- a/pkg/generator/controller.go
+++ b/pkg/generator/controller.go
@@ -82,8 +82,8 @@ func GenerateController(file string, data GenerateControllerData, generateFn Gen
 	return generateFn(input, nil)
 }
 
-// ----- Generate hello word -----
-func GenerateHelloWordController(basePath string, generateFn GenerateFn) (err error) {
+// ----- Generate hello world -----
+func GenerateHelloWorldController(basePath string, generateFn GenerateFn) (err error) {
 	controllerPath := filepath.Join(basePath, ControllerDir)
 	ControllerLogger.Trace("create controller folder if not exist", "path", controllerPath)
 	if exist := utils.IsFolderExists(controllerPath); !exist {
@@ -91,10 +91,10 @@ func GenerateHelloWordController(basePath string, generateFn GenerateFn) (err er
 			return err
 		}
 	}
-	return createHelloWordController(controllerPath, generateFn)
+	return createHelloWorldController(controllerPath, generateFn)
 }
 
-func createHelloWordController(controllerPath string, generateFn GenerateFn) error {
+func createHelloWorldController(controllerPath string, generateFn GenerateFn) error {
 	// set file path
 	filePath := filepath.Join(controllerPath, fmt.Sprintf("%s.go", "hello"))
 
@@ -114,7 +114,7 @@ func createHelloWordController(controllerPath string, generateFn GenerateFn) err
 	}
 
 	data := GenerateControllerData{
-		Name:           "HelloWord",
+		Name:           "HelloWorld",
 		Package:        "controllers",
 		HttpTag:        "`path:\"/hello/{name}\" type:\"custom\"`",
 		Imports:        imports,


### PR DESCRIPTION
What I Do:

1. Rename initialize word which contains 'hello word' into 'hello world'
2. Change default value of SERVER_HOST in yaml file generated

Tested:

- [x] self tested by running new binary has been built in my local and create a new project successfully

**Before:**
![Screenshot 2024-06-04 at 12 26 35](https://github.com/sev-2/raiden/assets/82171912/8293aa9b-ad9e-4283-8380-acad4e6623ed)
![Screenshot 2024-06-04 at 12 26 54](https://github.com/sev-2/raiden/assets/82171912/d1ef7d6f-90fa-47ef-8181-1fab2f411c92)

**After:**

![Screenshot 2024-06-04 at 14 29 26](https://github.com/sev-2/raiden/assets/82171912/c81928c8-5beb-4fb6-b099-1b3e3304e85b)
![Screenshot 2024-06-04 at 14 28 42](https://github.com/sev-2/raiden/assets/82171912/bec397bd-fc4c-42f1-80bc-39c0c54cb7df)



