### PR TITLE
tweak(job): initial generate of job

### DIFF
--- a/pkg/cli/configure/command.go
+++ b/pkg/cli/configure/command.go
@@ -73,11 +73,12 @@ func Run(f *Flags, projectPath string) (*Config, error) {
 func SimpleConfigure() (*Config, error) {
 	config := &Config{
 		raiden.Config{
-			BreakerEnable: true,
-			TraceEnable:   false,
-			Version:       "1.0.0",
-			ServerHost:    "127.0.0.1",
-			ServerPort:    "8002",
+			ScheduleStatus: "off",
+			BreakerEnable:  true,
+			TraceEnable:    false,
+			Version:        "1.0.0",
+			ServerHost:     "127.0.0.1",
+			ServerPort:     "8002",
 		},
 	}
 
@@ -129,6 +130,11 @@ func SimpleConfigure() (*Config, error) {
 	}
 
 	if err := PromptServiceKey(config); err != nil {
+		return nil, err
+	}
+
+	// Prompt Job
+	if err := PromptJob(config); err != nil {
 		return nil, err
 	}
 
@@ -372,6 +378,23 @@ func PromptBreakerEnable(c *Config) error {
 	}
 
 	c.BreakerEnable = inputBool
+	return nil
+}
+
+// ----- Prompt Job -----
+
+func PromptJob(c *Config) error {
+	input := confirmation.New("Would you like to turn initially on scheduler/cron job?", confirmation.No)
+	input.DefaultValue = confirmation.No
+
+	inputBool, err := input.RunPrompt()
+	if err != nil {
+		return err
+	}
+
+	if inputBool {
+		c.ScheduleStatus = "on"
+	}
 	return nil
 }
 

--- a/pkg/cli/configure/command.go
+++ b/pkg/cli/configure/command.go
@@ -384,7 +384,7 @@ func PromptBreakerEnable(c *Config) error {
 // ----- Prompt Job -----
 
 func PromptJob(c *Config) error {
-	input := confirmation.New("Would you like to turn initially on scheduler/cron job?", confirmation.No)
+	input := confirmation.New("Would you like to initially turned ON for the scheduler/cron job?", confirmation.No)
 	input.DefaultValue = confirmation.No
 
 	inputBool, err := input.RunPrompt()

--- a/pkg/cli/generate/command.go
+++ b/pkg/cli/generate/command.go
@@ -116,7 +116,14 @@ func Run(flags *Flags, config *raiden.Config, projectPath string, initialize boo
 					errChan <- err
 					return
 				}
-				GenerateLogger.Info("finish generate hello world controller")
+
+				// generate example job
+				GenerateLogger.Info("start generate hello world job")
+				if err := generator.GenerateHelloWorldJob(projectPath, generator.Generate); err != nil {
+					errChan <- err
+					return
+				}
+				GenerateLogger.Info("finish generate hello world job")
 			}
 
 			// generate route base on controllers

--- a/pkg/generator/config.go
+++ b/pkg/generator/config.go
@@ -35,6 +35,8 @@ SERVER_PORT: {{ .ServerPort }}
 ENVIRONMENT: development
 VERSION: 1.0.0
 
+SCHEDULE_STATUS: '{{ .ScheduleStatus }}'
+
 BREAKER_ENABLE: {{ .BreakerEnable }}
 
 TRACE_ENABLE: {{ .TraceEnable }}

--- a/pkg/generator/job.go
+++ b/pkg/generator/job.go
@@ -1,0 +1,118 @@
+package generator
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/sev-2/raiden/pkg/logger"
+	"github.com/sev-2/raiden/pkg/utils"
+)
+
+var JobLogger hclog.Logger = logger.HcLog().Named("generator.Job")
+
+// ----- Define type, variable and constant -----
+type JobFieldAttribute struct {
+	Field string
+	Type  string
+	Tag   string
+}
+
+type GenerateJobData struct {
+	Imports           []string
+	JobName           string
+	SnakeCasedJobName string
+	Package           string
+}
+
+const (
+	JobTemplate = `package {{ .Package }}
+{{- if gt (len .Imports) 0 }}
+
+import (
+{{- range .Imports}}
+	{{.}}
+{{- end}}
+)
+{{- end }}
+
+type {{ .JobName }}Job struct {
+	raiden.JobBase
+}
+
+func (j *{{ .JobName }}Job) Name() string {
+	return "{{ .SnakeCasedJobName }}"
+}
+
+func (j *{{ .JobName }}Job) Before(ctx raiden.JobContext, jobID uuid.UUID, jobName string) {
+	raiden.Info("before execute", "name", jobName)
+}
+
+func (j *{{ .JobName }}Job) After(ctx raiden.JobContext, jobID uuid.UUID, jobName string) {
+	raiden.Info("after execute", "name", jobName)
+}
+
+func (j *{{ .JobName }}Job) AfterErr(ctx raiden.JobContext, jobID uuid.UUID, jobName string, err error) {
+	raiden.Error("after execute with error", "message", err.Error())
+}
+
+func (j *{{ .JobName }}Job) Duration() gocron.JobDefinition {
+	return gocron.DurationJob(5 * time.Minute)
+}
+
+func (j *{{ .JobName }}Job) Task(ctx raiden.JobContext) error {
+	fmt.Printf("Hello at %s \n", time.Now().String())
+
+	return nil
+}
+`
+)
+
+// ----- Generate Job -----
+func GenerateJob(file string, data GenerateJobData, generateFn GenerateFn) error {
+	input := GenerateInput{
+		BindData:     data,
+		Template:     JobTemplate,
+		TemplateName: "jobName",
+		OutputPath:   file,
+	}
+	JobLogger.Debug("generate job", "path", input.OutputPath)
+	return generateFn(input, nil)
+}
+
+// ----- Generate hello world -----
+func GenerateHelloWorldJob(basePath string, generateFn GenerateFn) (err error) {
+	JobPath := filepath.Join(basePath, JobDir)
+	JobLogger.Trace("create jobs folder if not exist", "path", JobPath)
+	if exist := utils.IsFolderExists(JobPath); !exist {
+		if err := utils.CreateFolder(JobPath); err != nil {
+			return err
+		}
+	}
+	return createHelloWorldJob(JobPath, generateFn)
+}
+
+func createHelloWorldJob(JobPath string, generateFn GenerateFn) error {
+	// set file path
+	filePath := filepath.Join(JobPath, fmt.Sprintf("%s.go", "hello"))
+
+	// set imports path
+	imports := []string{
+		fmt.Sprintf("%q", "fmt"),
+		fmt.Sprintf("%q", "time"),
+
+		fmt.Sprintf("%q", "github.com/go-co-op/gocron/v2"),
+		fmt.Sprintf("%q", "github.com/google/uuid"),
+
+		fmt.Sprintf("%q", "github.com/sev-2/raiden"),
+	}
+
+	data := GenerateJobData{
+		Package:           "jobs",
+		JobName:           "HelloWorld",
+		SnakeCasedJobName: "hello_world_job",
+		Imports:           imports,
+	}
+
+	return GenerateJob(filePath, data, generateFn)
+}


### PR DESCRIPTION
### Proposal Enhancements
Added initial generate of jobs, so new comer can easily onboard to know how to setup job scheduler

### Resolution

1. Added generation code for initial job
2. Added SCHEDULE_STATUS at initial app.yaml
3. Configurable turn on/off prompt at `raiden start` cmd interaction

<img width="754" alt="image" src="https://github.com/sev-2/raiden/assets/11476348/83cacf54-5eb3-43db-b439-6639ae5d03f5">
