### PR TITLE
Fix import pkg/db

### DIFF
--- a/pkg/generator/model.go
+++ b/pkg/generator/model.go
@@ -113,8 +113,8 @@ func GenerateModel(folderPath string, input *GenerateModelInput, generateFn Gene
 	// map column data
 	columns, importsPath := MapTableAttributes(input.Table, input.ValidationTags)
 	rlsTag := BuildRlsTag(input.Policies, input.Table.Name, supabase.RlsTypeModel)
-	raidenPath := "github.com/sev-2/raiden"
-	importsPath = append(importsPath, raidenPath)
+	raidenPkgDbPath := "github.com/sev-2/raiden/pkg/db"
+	importsPath = append(importsPath, raidenPkgDbPath)
 
 	// define file path
 	filePath := filepath.Join(folderPath, fmt.Sprintf("%s.%s", input.Table.Name, "go"))


### PR DESCRIPTION
## Description

This patch to fix model generator. The `db.ModelBase` should imported from `github.com/sev-2/raiden/pkg/db`.

Before:
```go
import (
	"github.com/sev-2/raiden"
)

type ModelName struct {
	db.ModelBase // undefined db
}
```

After:
```go
import (
	"github.com/sev-2/raiden/pkg/db"
)

type ModelName struct {
	db.ModelBase
}
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Unit Tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
