### PR TITLE
fix #60 add configurable MaxRequestBodySize of fasthttp

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,28 +16,29 @@ const (
 )
 
 type Config struct {
-	AccessToken            string           `mapstructure:"ACCESS_TOKEN"`
-	AnonKey                string           `mapstructure:"ANON_KEY"`
-	BreakerEnable          bool             `mapstructure:"BREAKER_ENABLE"`
-	CorsAllowedOrigins     string           `mapstructure:"CORS_ALLOWED_ORIGINS"`
-	CorsAllowedMethods     string           `mapstructure:"CORS_ALLOWED_METHODS"`
-	CorsAllowedHeaders     string           `mapstructure:"CORS_ALLOWED_HEADERS"`
-	CorsAllowCredentials   bool             `mapstructure:"CORS_ALLOWED_CREDENTIALS"`
-	DeploymentTarget       DeploymentTarget `mapstructure:"DEPLOYMENT_TARGET"`
-	Environment            string           `mapstructure:"ENVIRONMENT"`
-	ProjectId              string           `mapstructure:"PROJECT_ID"`
-	ProjectName            string           `mapstructure:"PROJECT_NAME"`
-	ServiceKey             string           `mapstructure:"SERVICE_KEY"`
-	ServerHost             string           `mapstructure:"SERVER_HOST"`
-	ServerPort             string           `mapstructure:"SERVER_PORT"`
-	SupabaseApiUrl         string           `mapstructure:"SUPABASE_API_URL"`
-	SupabaseApiBasePath    string           `mapstructure:"SUPABASE_API_BASE_PATH"`
-	SupabasePublicUrl      string           `mapstructure:"SUPABASE_PUBLIC_URL"`
-	ScheduleStatus         ScheduleStatus   `mapstructure:"SCHEDULE_STATUS"`
-	TraceEnable            bool             `mapstructure:"TRACE_ENABLE"`
-	TraceCollector         string           `mapstructure:"TRACE_COLLECTOR"`
-	TraceCollectorEndpoint string           `mapstructure:"TRACE_COLLECTOR_ENDPOINT"`
-	Version                string           `mapstructure:"VERSION"`
+	AccessToken              string           `mapstructure:"ACCESS_TOKEN"`
+	AnonKey                  string           `mapstructure:"ANON_KEY"`
+	BreakerEnable            bool             `mapstructure:"BREAKER_ENABLE"`
+	CorsAllowedOrigins       string           `mapstructure:"CORS_ALLOWED_ORIGINS"`
+	CorsAllowedMethods       string           `mapstructure:"CORS_ALLOWED_METHODS"`
+	CorsAllowedHeaders       string           `mapstructure:"CORS_ALLOWED_HEADERS"`
+	CorsAllowCredentials     bool             `mapstructure:"CORS_ALLOWED_CREDENTIALS"`
+	DeploymentTarget         DeploymentTarget `mapstructure:"DEPLOYMENT_TARGET"`
+	Environment              string           `mapstructure:"ENVIRONMENT"`
+	ProjectId                string           `mapstructure:"PROJECT_ID"`
+	ProjectName              string           `mapstructure:"PROJECT_NAME"`
+	ServiceKey               string           `mapstructure:"SERVICE_KEY"`
+	ServerHost               string           `mapstructure:"SERVER_HOST"`
+	ServerPort               string           `mapstructure:"SERVER_PORT"`
+	SupabaseApiUrl           string           `mapstructure:"SUPABASE_API_URL"`
+	SupabaseApiBasePath      string           `mapstructure:"SUPABASE_API_BASE_PATH"`
+	SupabasePublicUrl        string           `mapstructure:"SUPABASE_PUBLIC_URL"`
+	ScheduleStatus           ScheduleStatus   `mapstructure:"SCHEDULE_STATUS"`
+	TraceEnable              bool             `mapstructure:"TRACE_ENABLE"`
+	TraceCollector           string           `mapstructure:"TRACE_COLLECTOR"`
+	TraceCollectorEndpoint   string           `mapstructure:"TRACE_COLLECTOR_ENDPOINT"`
+	Version                  string           `mapstructure:"VERSION"`
+	MaxServerRequestBodySize int              `mapstructure:"MAX_SERVER_REQUEST_BODY_SIZE"`
 }
 
 // The function `LoadConfig` loads a configuration file based on the provided path or uses default
@@ -91,6 +92,10 @@ func LoadConfig(path *string) (*Config, error) {
 
 	if len(config.SupabaseApiBasePath) > 0 && config.SupabaseApiBasePath[0] != '/' {
 		config.SupabaseApiBasePath = "/" + config.SupabaseApiBasePath
+	}
+
+	if config.MaxServerRequestBodySize == 0 {
+		config.MaxServerRequestBodySize = 8 * 1024 * 1024 // Default Max: 8 MB
 	}
 
 	return &config, nil

--- a/pkg/generator/config.go
+++ b/pkg/generator/config.go
@@ -43,6 +43,8 @@ TRACE_ENABLE: {{ .TraceEnable }}
 TRACE_COLLECTOR: {{ .TraceCollector}}
 TRACE_COLLECTOR_ENDPOINT: {{ .TraceCollectorEndpoint }}
 
+MAX_SERVER_REQUEST_BODY_SIZE: {{ .MaxServerRequestBodySize }}
+
 CORS_ALLOWED_ORIGINS:
 CORS_ALLOWED_METHODS:
 CORS_ALLOWED_HEADERS:
@@ -67,6 +69,10 @@ func GenerateConfig(basePath string, config *raiden.Config, generateFn GenerateF
 
 	if config.ServerPort == "" {
 		config.ServerPort = "8002"
+	}
+
+	if config.MaxServerRequestBodySize == 0 {
+		config.MaxServerRequestBodySize = 8 * 1024 * 1024
 	}
 
 	input := GenerateInput{

--- a/server.go
+++ b/server.go
@@ -34,9 +34,11 @@ type Server struct {
 
 func NewServer(config *Config) *Server {
 	return &Server{
-		Config:     config,
-		Router:     NewRouter(config),
-		HttpServer: &fasthttp.Server{},
+		Config: config,
+		Router: NewRouter(config),
+		HttpServer: &fasthttp.Server{
+			MaxRequestBodySize: config.MaxServerRequestBodySize,
+		},
 	}
 }
 


### PR DESCRIPTION
## Description

Fix #60

- setup fasthttp.Server now always read MaxRequestBodySize from configuration
- Added MAX_SERVER_REQUEST_BODY_SIZE to default configration in app.yaml
- Add default value to 8 MB if not set

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Unit Tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please add screenshots to help explain your changes.

## Further comments

If this is a large or complex change, please explain why you believe it should be accepted and what are the benefits.
