### PR TITLE
FEAT Always return representation after write operation

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -353,6 +353,9 @@ func (rc RestController) Put(ctx Context) error {
 		return err1
 	}
 
+	// Set prefer representation header as default
+	ctx.RequestContext().Request.Header.Add("Prefer", "return=representation")
+
 	return RestProxy(ctx, rc.TableName)
 }
 

--- a/controller.go
+++ b/controller.go
@@ -309,6 +309,9 @@ func (rc RestController) Patch(ctx Context) error {
 		return err1
 	}
 
+	// Set prefer representation header as default
+	ctx.RequestContext().Request.Header.Add("Prefer", "return=representation")
+
 	return RestProxy(ctx, rc.TableName)
 }
 
@@ -331,6 +334,9 @@ func (rc RestController) Post(ctx Context) error {
 	if err1 := Validate(model); err1 != nil {
 		return err1
 	}
+
+	// Set prefer representation header as default
+	ctx.RequestContext().Request.Header.Add("Prefer", "return=representation")
 
 	return RestProxy(ctx, rc.TableName)
 }

--- a/pkg/db/relation.go
+++ b/pkg/db/relation.go
@@ -32,7 +32,7 @@ func (q *Query) Preload(table string, args ...string) *Query {
 	relations := strings.Split(table, ".")
 
 	if len(relations) > 3 {
-		raiden.Fatal("unsupported nested relations more than 3 levels")
+		raiden.Panic("unsupported nested relations more than 3 levels")
 	}
 
 	for i, relation := range relations {
@@ -48,7 +48,7 @@ func (q *Query) Preload(table string, args ...string) *Query {
 		}
 
 		if err != nil {
-			raiden.Fatal("could not find related model.")
+			raiden.Panic("could not find related model.")
 		}
 
 		relatedModelStruct := reflect.TypeOf(relatedModel)
@@ -80,7 +80,7 @@ func (q *Query) Preload(table string, args ...string) *Query {
 				relatedForeignKey, err = getTagValue(join, "foreignKey")
 
 				if err != nil {
-					raiden.Fatal("could not find foreign key in join tag.")
+					raiden.Panic("could not find foreign key in join tag.")
 				}
 			}
 		}

--- a/pkg/db/select.go
+++ b/pkg/db/select.go
@@ -23,7 +23,7 @@ func (q Query) Select(columns []string) (model *Query) {
 			column = split[1]
 			if !isValidColumnName(alias) {
 				err := fmt.Sprintf("invalid alias column name: \"%s\" name is invalid.", alias)
-				raiden.Fatal(err)
+				raiden.Panic(err)
 			}
 		} else {
 			column = c


### PR DESCRIPTION
## Description

This PR modifies the behavior of write operations in the system to ensure that a representation of the affected resource is always returned after a write operation (such as POST, PUT, or PATCH).

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
Returning a representation after a write operation aligns with common RESTful API practices and provides several benefits:

Immediate Feedback: After a resource is created, updated, or modified, the client needs confirmation of the result. Returning the updated resource provides immediate feedback to confirm that the operation was successful and how the resource looks after the change.

Reduced API Calls: By returning the resource immediately, the client does not need to make an additional GET request to retrieve the updated representation, reducing the number of API calls and improving efficiency.

Data Integrity Verification: Returning the resource enables the client to verify the integrity and consistency of the data after the write operation, ensuring that all fields are properly updated and no data is lost or modified incorrectly.

Standards Compliance: This approach follows REST principles, particularly the best practice of returning the new state of the resource after modifying it. For example, after a POST request to create a new resource, the API should return the newly created resource with all relevant fields (e.g., auto-generated ID or timestamps). Similarly, after a PUT or PATCH, the updated resource should be returned.