### PR TITLE
hotfix: remove return representation header

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -309,9 +309,6 @@ func (rc RestController) Patch(ctx Context) error {
 		return err1
 	}
 
-	// Set prefer representation header as default
-	ctx.RequestContext().Request.Header.Add("Prefer", "return=representation")
-
 	return RestProxy(ctx, rc.TableName)
 }
 
@@ -335,9 +332,6 @@ func (rc RestController) Post(ctx Context) error {
 		return err1
 	}
 
-	// Set prefer representation header as default
-	ctx.RequestContext().Request.Header.Add("Prefer", "return=representation")
-
 	return RestProxy(ctx, rc.TableName)
 }
 
@@ -352,9 +346,6 @@ func (rc RestController) Put(ctx Context) error {
 	if err1 := Validate(model); err1 != nil {
 		return err1
 	}
-
-	// Set prefer representation header as default
-	ctx.RequestContext().Request.Header.Add("Prefer", "return=representation")
 
 	return RestProxy(ctx, rc.TableName)
 }


### PR DESCRIPTION
## Description

The preferred return representation interferes with RLS in some cases, making it difficult to optimize performance and leading to potential inconsistencies in certain scenarios.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
