### PR TITLE
feature : support push subscription

### DIFF
--- a/config.go
+++ b/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	ServiceKey               string           `mapstructure:"SERVICE_KEY"`
 	ServerHost               string           `mapstructure:"SERVER_HOST"`
 	ServerPort               string           `mapstructure:"SERVER_PORT"`
+	ServerDns                string           `mapstructure:"SERVER_DNS"`
 	SupabaseApiUrl           string           `mapstructure:"SUPABASE_API_URL"`
 	SupabaseApiBasePath      string           `mapstructure:"SUPABASE_API_BASE_PATH"`
 	SupabasePublicUrl        string           `mapstructure:"SUPABASE_PUBLIC_URL"`

--- a/context.go
+++ b/context.go
@@ -97,7 +97,7 @@ func (c *Ctx) SetJobChan(jobChan chan JobParams) {
 
 func (c *Ctx) NewJobCtx() (JobContext, error) {
 	if c.jobChan != nil {
-		jobCtx := newJobCtx(c.config, c.jobChan, make(JobData))
+		jobCtx := newJobCtx(c.config, c.pubSub, c.jobChan, make(JobData))
 		spanCtx := trace.SpanContextFromContext(c.Context)
 		jobCtx.SetContext(trace.ContextWithSpanContext(context.Background(), spanCtx))
 		return jobCtx, nil

--- a/pkg/cli/configure/command.go
+++ b/pkg/cli/configure/command.go
@@ -581,6 +581,32 @@ func PromptGoogleSaPath(c *Config) error {
 	return nil
 }
 
+func PromptGooglePubsubPushSubscription() (bool, error) {
+	input := confirmation.New("Would you like to to use 'push' subscription ?", confirmation.No)
+	input.DefaultValue = confirmation.No
+	return input.RunPrompt()
+}
+
+// ----- Prompt Server Dsn -----
+func PromptServerDsn(c *Config) error {
+	input := textinput.New("Enter your server dns (current service public url include protocol)")
+	input.Validate = func(s string) error {
+		if len(s) == 0 || s == "" {
+			return errors.New("server dns is required")
+		}
+
+		return nil
+	}
+
+	inputText, err := input.RunPrompt()
+	if err != nil {
+		return err
+	}
+
+	c.ServerDns = inputText
+	return nil
+}
+
 // ----- Check and generate functionality -----
 
 func Generate(config *raiden.Config, projectPath string) error {

--- a/pkg/db/aggregate.go
+++ b/pkg/db/aggregate.go
@@ -38,7 +38,7 @@ func (q *Query) Count(opts ...CountOptions) (int, error) {
 	headers["Range-Unit"] = "items"
 
 	var a interface{}
-	resp, err := PostgrestRequestBind(q.Context, fasthttp.MethodHead, url, nil, headers, q.ByPass, &a)
+	resp, err := PostgrestRequest(q.Context, q.credential, fasthttp.MethodHead, url, nil, headers, q.ByPass, &a)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -10,6 +10,11 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+type Credential struct {
+	Token  string
+	ApiKey string
+}
+
 type Query struct {
 	Context      raiden.Context
 	model        interface{}
@@ -23,6 +28,7 @@ type Query struct {
 	OffsetValue  int
 	Errors       []error
 	ByPass       bool
+	credential   Credential
 }
 
 type ModelBase struct {
@@ -38,6 +44,11 @@ func NewQuery(ctx raiden.Context) *Query {
 		Context: ctx,
 		ByPass:  false,
 	}
+}
+
+func (q *Query) SetCredential(credential Credential) *Query {
+	q.credential = credential
+	return q
 }
 
 // Model is the From alias
@@ -85,7 +96,7 @@ func (q Query) Get(collection interface{}) error {
 	headers["Content-Type"] = "application/json"
 	headers["Prefer"] = "return=representation"
 
-	_, err := PostgrestRequestBind(q.Context, fasthttp.MethodGet, url, nil, headers, q.ByPass, collection)
+	_, err := PostgrestRequest(q.Context, q.credential, fasthttp.MethodGet, url, nil, headers, q.ByPass, collection)
 	if err != nil {
 		return err
 	}
@@ -100,7 +111,7 @@ func (q Query) Single(model interface{}) error {
 
 	headers["Accept"] = "application/vnd.pgrst.object+json"
 
-	_, err := PostgrestRequestBind(q.Context, "GET", url, nil, headers, q.ByPass, model)
+	_, err := PostgrestRequest(q.Context, q.credential, "GET", url, nil, headers, q.ByPass, model)
 	if err != nil {
 		return err
 	}

--- a/pkg/db/delete.go
+++ b/pkg/db/delete.go
@@ -12,7 +12,7 @@ func (q *Query) Delete() error {
 	headers["Prefer"] = "return=representation"
 
 	var a interface{}
-	_, err := PostgrestRequestBind(q.Context, fasthttp.MethodDelete, url, nil, headers, q.ByPass, &a)
+	_, err := PostgrestRequest(q.Context, q.credential, fasthttp.MethodDelete, url, nil, headers, q.ByPass, &a)
 	if err != nil {
 		return err
 	}

--- a/pkg/db/insert.go
+++ b/pkg/db/insert.go
@@ -18,7 +18,7 @@ func (q *Query) Insert(payload interface{}, model interface{}) error {
 	headers["Content-Type"] = "application/json"
 	headers["Prefer"] = "return=representation"
 
-	_, err0 := PostgrestRequestBind(q.Context, fasthttp.MethodPost, url, jsonData, headers, q.ByPass, model)
+	_, err0 := PostgrestRequest(q.Context, q.credential, fasthttp.MethodPost, url, jsonData, headers, q.ByPass, model)
 	if err0 != nil {
 		return err0
 	}

--- a/pkg/db/postgrest_request.go
+++ b/pkg/db/postgrest_request.go
@@ -174,7 +174,6 @@ func PostgrestRequestBindCredential(credential Credential, method string, url st
 	defer fasthttp.ReleaseResponse(res)
 
 	if err := client.Do(req, res); err != nil {
-		fmt.Println("err : ", err.Error())
 		return res, err
 	}
 

--- a/pkg/db/postgrest_request.go
+++ b/pkg/db/postgrest_request.go
@@ -10,6 +10,13 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+func PostgrestRequest(ctx raiden.Context, credential Credential, method string, url string, payload []byte, headers map[string]string, bypass bool, result interface{}) (*fasthttp.Response, error) {
+	if ctx != nil {
+		return PostgrestRequestBind(ctx, method, url, payload, headers, bypass, result)
+	}
+	return PostgrestRequestBindCredential(credential, method, url, payload, headers, bypass, result)
+}
+
 func PostgrestRequestBind(ctx raiden.Context, method string, url string, payload []byte, headers map[string]string, bypass bool, result interface{}) (*fasthttp.Response, error) {
 
 	if !isAllowedMethod(method) {
@@ -80,6 +87,94 @@ func PostgrestRequestBind(ctx raiden.Context, method string, url string, payload
 	defer fasthttp.ReleaseResponse(res)
 
 	if err := client.Do(req, res); err != nil {
+		return res, err
+	}
+
+	body := res.Body()
+
+	if result != nil {
+		if err := json.Unmarshal(body, result); err != nil {
+			return res, fmt.Errorf("failed to unmarshal response body: %w", err)
+		}
+	}
+
+	return res, nil
+}
+
+func PostgrestRequestBindCredential(credential Credential, method string, url string, payload []byte, headers map[string]string, bypass bool, result interface{}) (*fasthttp.Response, error) {
+	if !isAllowedMethod(method) {
+		return nil, fmt.Errorf("method %s is not allowed", method)
+	}
+
+	client := &fasthttp.Client{}
+
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+
+	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+		var baseUrl string
+		if flag.Lookup("test.v") != nil {
+			baseUrl = "https://api.supabase.co"
+		} else {
+			baseUrl = getConfig().SupabasePublicUrl
+
+			if getConfig().Mode == raiden.SvcMode {
+				baseUrl = getConfig().PostgRestUrl
+			}
+		}
+
+		if getConfig() != nil && getConfig().Mode == raiden.SvcMode {
+			if strings.HasPrefix(url, "/") {
+				url = fmt.Sprintf("%s%s", baseUrl, url)
+			} else {
+				url = fmt.Sprintf("%s/%s", baseUrl, url)
+			}
+		} else {
+			if strings.HasPrefix(url, "/") {
+				url = fmt.Sprintf("%s/rest/v1%s", baseUrl, url)
+			} else {
+				url = fmt.Sprintf("%s/rest/v1/%s", baseUrl, url)
+			}
+		}
+
+	}
+
+	req.SetRequestURI(url)
+	req.Header.SetMethod(method)
+
+	if bypass {
+		if flag.Lookup("test.v") == nil {
+			req.Header.Set("apikey", getConfig().ServiceKey)
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", getConfig().ServiceKey))
+		}
+	} else {
+
+		if credential.ApiKey != "" {
+			req.Header.Set("apikey", credential.ApiKey)
+		}
+
+		if credential.Token != "" {
+			if strings.HasPrefix(credential.Token, "Bearer ") {
+				req.Header.Set("Authorization", credential.Token)
+			} else {
+				req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", credential.Token))
+			}
+		}
+	}
+
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+
+	if payload != nil {
+		req.SetBody(payload)
+	}
+
+	res := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(res)
+
+	if err := client.Do(req, res); err != nil {
+		fmt.Println("err : ", err.Error())
 		return res, err
 	}
 

--- a/pkg/db/update.go
+++ b/pkg/db/update.go
@@ -29,7 +29,7 @@ func (q *Query) Update(p interface{}, model interface{}) error {
 	headers["Content-Type"] = "application/json"
 	headers["Prefer"] = "return=representation"
 
-	_, err0 := PostgrestRequestBind(q.Context, fasthttp.MethodPatch, url, jsonData, headers, q.ByPass, model)
+	_, err0 := PostgrestRequest(q.Context, q.credential, fasthttp.MethodPatch, url, jsonData, headers, q.ByPass, model)
 	if err0 != nil {
 		return err0
 	}

--- a/pkg/db/upsert.go
+++ b/pkg/db/upsert.go
@@ -28,7 +28,7 @@ func (q *Query) Upsert(payload []interface{}, opt UpsertOptions) error {
 	headers["Prefer"] = "resolution=" + opt.OnConflict
 
 	var a interface{}
-	_, err0 := PostgrestRequestBind(q.Context, fasthttp.MethodPost, url, jsonData, headers, q.ByPass, &a)
+	_, err0 := PostgrestRequest(q.Context, q.credential, fasthttp.MethodPost, url, jsonData, headers, q.ByPass, &a)
 	if err0 != nil {
 		return err0
 	}

--- a/pkg/generator/config.go
+++ b/pkg/generator/config.go
@@ -40,6 +40,7 @@ PG_META_URL: {{ .PgMetaUrl }}
 
 SERVER_HOST: {{ .ServerHost }}
 SERVER_PORT: {{ .ServerPort }}
+SERVER_DNS: {{ .ServerDns }}
 
 ENVIRONMENT: development
 VERSION: 1.0.0

--- a/pkg/generator/subscriber_register_test.go
+++ b/pkg/generator/subscriber_register_test.go
@@ -48,7 +48,7 @@ func (s *RideHailingSubscriber) Provider() raiden.PubSubProviderType {
 	return raiden.PubSubProviderGoogle
 }
 
-func (s *RideHailingSubscriber) Topic() string {
+func (s *RideHailingSubscriber) Subscripbtion() string {
 	return "transaction.ride-hailing.new-sub"
 }
 

--- a/pkg/mock/provider.go
+++ b/pkg/mock/provider.go
@@ -7,14 +7,20 @@ import (
 )
 
 type MockProvider struct {
-	PublishFn     func(ctx context.Context, topic string, message []byte) error
-	StartListenFn func(handler []raiden.SubscriberHandler) error
-	StopListenFn  func() error
+	CreateSubscriptionFn func(handler raiden.SubscriberHandler) error
+	PublishFn            func(ctx context.Context, topic string, message []byte) error
+	StartListenFn        func(handler []raiden.SubscriberHandler) error
+	StopListenFn         func() error
 }
 
 // Publish implements raiden.PubSubProvider.
 func (m *MockProvider) Publish(ctx context.Context, topic string, message []byte) error {
 	return m.PublishFn(ctx, topic, message)
+}
+
+// Publish implements raiden.PubSubProvider.
+func (m *MockProvider) CreateSubscription(handler raiden.SubscriberHandler) error {
+	return m.CreateSubscriptionFn(handler)
 }
 
 // StartListen implements raiden.PubSubProvider.

--- a/pkg/mock/pubsub.go
+++ b/pkg/mock/pubsub.go
@@ -9,13 +9,18 @@ import (
 )
 
 type MockPubSubClient struct {
-	Subscriptions map[string]*MockSubscription
-	Topics        map[string]*MockTopic
-	CloseFn       func() error
+	Subscriptions        map[string]*MockSubscription
+	Topics               map[string]*MockTopic
+	CloseFn              func() error
+	CreateSubscriptionFn func(ctx context.Context, id string, cfg pubsub.SubscriptionConfig) (google.Subscription, error)
 }
 
 func (m *MockPubSubClient) Subscription(id string) google.Subscription {
 	return m.Subscriptions[id]
+}
+
+func (m *MockPubSubClient) CreateSubscription(ctx context.Context, id string, cfg pubsub.SubscriptionConfig) (google.Subscription, error) {
+	return m.CreateSubscriptionFn(ctx, id, cfg)
 }
 
 func (m *MockPubSubClient) Topic(id string) google.Topic {
@@ -47,6 +52,10 @@ func (m *MockTopic) Publish(ctx context.Context, msg *pubsub.Message) google.Pub
 	return m.PublishFn(ctx, msg)
 }
 
+func (m *MockTopic) GetInstance() *pubsub.Topic {
+	return nil
+}
+
 type MockPublishResult struct {
 	Result string
 	Err    error
@@ -57,19 +66,34 @@ func (m *MockPublishResult) Get(ctx context.Context) (string, error) {
 }
 
 type MockSubscriberHandler struct {
-	TopicValue    string
-	NameValue     string
-	AutoAckValue  bool
-	ProviderValue raiden.PubSubProviderType
-	ConsumeFunc   func(ctx raiden.SubscriberContext, msg any) error
+	TopicValue            string
+	SubscriptionValue     string
+	NameValue             string
+	PushEndpointValue     string
+	AutoAckValue          bool
+	ProviderValue         raiden.PubSubProviderType
+	SubscriptionTypeValue raiden.SubscriptionType
+	ConsumeFunc           func(ctx raiden.SubscriberContext, msg any) error
 }
 
 func (m *MockSubscriberHandler) Provider() raiden.PubSubProviderType {
 	return m.ProviderValue
 }
 
+func (m *MockSubscriberHandler) Subscription() string {
+	return m.SubscriptionValue
+}
+
 func (m *MockSubscriberHandler) Topic() string {
 	return m.TopicValue
+}
+
+func (m *MockSubscriberHandler) PushEndpoint() string {
+	return m.PushEndpointValue
+}
+
+func (m *MockSubscriberHandler) SubscriptionType() raiden.SubscriptionType {
+	return m.SubscriptionTypeValue
 }
 
 func (m *MockSubscriberHandler) Name() string {

--- a/pkg/pubsub/google/wrapper.go
+++ b/pkg/pubsub/google/wrapper.go
@@ -8,6 +8,7 @@ import (
 
 // PubSubClient defines the methods required for Pub/Sub client interaction.
 type PubSubClient interface {
+	CreateSubscription(ctx context.Context, id string, cfg pubsub.SubscriptionConfig) (Subscription, error)
 	Subscription(id string) Subscription
 	Topic(id string) Topic
 	Close() error
@@ -22,6 +23,7 @@ type Subscription interface {
 // Topic defines the methods required for publishing messages.
 type Topic interface {
 	Publish(ctx context.Context, msg *pubsub.Message) PublishResult
+	GetInstance() *pubsub.Topic
 }
 
 // PublishResult abstracts the result of publishing a message.
@@ -35,6 +37,11 @@ type GooglePubSubClient struct {
 
 func (g *GooglePubSubClient) Subscription(id string) Subscription {
 	return &GoogleSubscription{subscription: g.Client.Subscription(id)}
+}
+
+func (g *GooglePubSubClient) CreateSubscription(ctx context.Context, id string, cfg pubsub.SubscriptionConfig) (Subscription, error) {
+	sub, err := g.Client.CreateSubscription(context.Background(), id, cfg)
+	return &GoogleSubscription{subscription: sub}, err
 }
 
 func (g *GooglePubSubClient) Topic(id string) Topic {
@@ -63,6 +70,10 @@ type GoogleTopic struct {
 
 func (g *GoogleTopic) Publish(ctx context.Context, msg *pubsub.Message) PublishResult {
 	return &GooglePublishResult{result: g.topic.Publish(ctx, msg)}
+}
+
+func (g *GoogleTopic) GetInstance() *pubsub.Topic {
+	return g.topic
 }
 
 type GooglePublishResult struct {

--- a/pubsub.go
+++ b/pubsub.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 
 	"cloud.google.com/go/pubsub"
@@ -365,7 +366,9 @@ func (s *GooglePubSubProvider) StartListen(handler []SubscriberHandler) error {
 	var group run.Group
 	for _, h := range handler {
 		sub := s.Client.Subscription(h.Subscription())
-		group.Add(s.listen(sub, h), func(err error) {})
+		group.Add(s.listen(sub, h), func(err error) {
+			os.Exit(1)
+		})
 	}
 
 	return group.Run()

--- a/pubsub.go
+++ b/pubsub.go
@@ -351,7 +351,7 @@ func (s *GooglePubSubProvider) CreateSubscription(handler SubscriberHandler) err
 	}
 
 	if s.Config.ServerDns == "" {
-		return errors.New("the SERVER_DSN configuration is required when using the 'push' subscription type.")
+		return errors.New("the SERVER_DSN configuration is required when using the 'push' subscription type")
 	}
 
 	if s.Client == nil {

--- a/pubsub.go
+++ b/pubsub.go
@@ -215,20 +215,32 @@ func (s *PubSubManager) Serve(handler SubscriberHandler) (fasthttp.RequestHandle
 			response["message"] = err.Error()
 			resByte, err := json.Marshal(response)
 			if err != nil {
-				ctx.WriteString(fmt.Sprintf("{\"message\":\"%s\"}", err.Error()))
+				errMsg := fmt.Sprintf("{\"message\":\"%s\"}", err.Error())
+				if _, writeErr := ctx.WriteString(errMsg); writeErr != nil {
+					// Log the error if necessary
+					PubSubLogger.Error(fmt.Sprintf("%s endpoint handler ctx.WriteString() error", handler.Name()), "message", writeErr)
+				}
 				return
 			}
 
-			ctx.Write(resByte)
+			if _, err := ctx.Write(resByte); err != nil {
+				PubSubLogger.Error(fmt.Sprintf("%s endpoint handler ctx.Write() error", handler.Name()), "message", err)
+			}
 			return
 		}
 
 		resByte, err := json.Marshal(response)
 		if err != nil {
-			ctx.WriteString(fmt.Sprintf("{\"message\":\"%s\"}", err.Error()))
+			errMsg := fmt.Sprintf("{\"message\":\"%s\"}", err.Error())
+			if _, writeErr := ctx.WriteString(errMsg); writeErr != nil {
+				// Log the error if necessary
+				PubSubLogger.Error(fmt.Sprintf("%s endpoint handler ctx.WriteString() error in last step", handler.Name()), "message", writeErr)
+			}
 			return
 		}
-		ctx.Write(resByte)
+		if _, err := ctx.Write(resByte); err != nil {
+			PubSubLogger.Error(fmt.Sprintf("%s endpoint handler ctx.Write() error ins last step", handler.Name()), "message", err)
+		}
 	}, nil
 
 }

--- a/pubsub.go
+++ b/pubsub.go
@@ -2,14 +2,17 @@ package raiden
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"cloud.google.com/go/pubsub"
 	"github.com/oklog/run"
 	"github.com/sev-2/raiden/pkg/logger"
 	"github.com/sev-2/raiden/pkg/pubsub/google"
+	"github.com/valyala/fasthttp"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/api/option"
 )
@@ -23,6 +26,26 @@ const (
 	PubSubProviderGoogle  PubSubProviderType = "google"
 	PubSubProviderUnknown PubSubProviderType = "unknown"
 )
+
+type SubscriptionType string
+
+const (
+	SubscriptionTypePull SubscriptionType = "pull"
+	SubscriptionTypePush SubscriptionType = "push"
+)
+
+const SubscriptionPrefixEndpoint = "pubsub-endpoint"
+
+type PushSubscriptionMessage struct {
+	Data         string `json:"data"`
+	MessageId    string `json:"message_id"`
+	Publish_time string `json:"publish_time"`
+}
+
+type PushSubscriptionData struct {
+	Message      PushSubscriptionMessage `json:"message"`
+	Subscription string                  `json:"subscription"`
+}
 
 // ----- Subscription Context -----
 type SubscriberContext interface {
@@ -51,11 +74,14 @@ func (ctx *subscriberContext) SetSpan(span trace.Span) {
 
 // ----- Subscription Handler -----
 type SubscriberHandler interface {
-	Name() string
-	Provider() PubSubProviderType
-	Topic() string
 	AutoAck() bool
+	Name() string
 	Consume(ctx SubscriberContext, message any) error
+	Provider() PubSubProviderType
+	PushEndpoint() string
+	Subscription() string
+	SubscriptionType() SubscriptionType
+	Topic() string
 }
 
 type SubscriberBase struct{}
@@ -72,12 +98,38 @@ func (s *SubscriberBase) Provider() PubSubProviderType {
 	return PubSubProviderUnknown
 }
 
+func (s *SubscriberBase) Subscription() string {
+	return ""
+}
+
+func (s *SubscriberBase) PushEndpoint() string {
+	return ""
+}
+
 func (s *SubscriberBase) Topic() string {
 	return ""
 }
 
+func (s *SubscriberBase) SubscriptionType() SubscriptionType {
+	return SubscriptionTypePull
+}
+
 func (s *SubscriberBase) Consume(ctx SubscriberContext, message any) error {
 	return fmt.Errorf("subscriber %s in not implemented", s.Name())
+}
+
+func (s *SubscriberBase) ParsePushSubscriptionMessage(message any) (*PushSubscriptionData, error) {
+	byteData, valid := message.([]byte)
+	if !valid {
+		return nil, errors.New("push subscription message is not valid")
+	}
+
+	var data PushSubscriptionData
+	if err := json.Unmarshal(byteData, &data); err != nil {
+		return nil, err
+	}
+
+	return &data, nil
 }
 
 // ----- Subscription Server -----
@@ -85,6 +137,8 @@ type PubSub interface {
 	Register(handler SubscriberHandler)
 	Publish(ctx context.Context, provider PubSubProviderType, topic string, message []byte) error
 	Listen()
+	Serve(handle SubscriberHandler) (fasthttp.RequestHandler, error)
+	Handlers() []SubscriberHandler
 }
 
 func NewPubsub(config *Config, tracer trace.Tracer) PubSub {
@@ -116,6 +170,10 @@ func (s *PubSubManager) Register(handler SubscriberHandler) {
 	s.handlers = append(s.handlers, handler)
 }
 
+func (s *PubSubManager) Handlers() []SubscriberHandler {
+	return s.handlers
+}
+
 func (s *PubSubManager) GetHandlerCount() int {
 	return len(s.handlers)
 }
@@ -131,28 +189,74 @@ func (s *PubSubManager) SetProvider(providerType PubSubProviderType, provider Pu
 	}
 }
 
+func (s *PubSubManager) Serve(handler SubscriberHandler) (fasthttp.RequestHandler, error) {
+
+	if handler.SubscriptionType() != SubscriptionTypePush {
+		return nil, fmt.Errorf("subscription %s is not push subscription", handler.Name())
+	}
+
+	if err := s.provider.google.CreateSubscription(handler); err != nil {
+		return nil, err
+	}
+
+	return func(ctx *fasthttp.RequestCtx) {
+		var subCtx = subscriberContext{
+			cfg: s.config, Context: context.Background(),
+		}
+
+		ctx.SetContentType("application/json")
+		response := map[string]any{
+			"message": "success handle",
+		}
+
+		if err := handler.Consume(&subCtx, ctx.Request.Body()); err != nil {
+			ctx.SetStatusCode(http.StatusInternalServerError)
+			response["message"] = err.Error()
+			resByte, err := json.Marshal(response)
+			if err != nil {
+				ctx.WriteString(fmt.Sprintf("{\"message\":\"%s\"}", err.Error()))
+				return
+			}
+
+			ctx.Write(resByte)
+			return
+		}
+
+		resByte, err := json.Marshal(response)
+		if err != nil {
+			ctx.WriteString(fmt.Sprintf("{\"message\":\"%s\"}", err.Error()))
+			return
+		}
+		ctx.Write(resByte)
+	}, nil
+
+}
+
 // StartListen implements Subscriber.
 func (s *PubSubManager) Listen() {
 	var g run.Group
 
-	var googleHandlers []SubscriberHandler
+	var googlePullHandlers []SubscriberHandler
 	for _, h := range s.handlers {
-		if h.Provider() == PubSubProviderGoogle {
-			googleHandlers = append(googleHandlers, h)
+		if h.Provider() == PubSubProviderGoogle && h.SubscriptionType() == SubscriptionTypePull {
+			googlePullHandlers = append(googlePullHandlers, h)
 		}
 	}
 
-	g.Add(func() error {
-		return s.provider.google.StartListen(googleHandlers)
-	}, func(err error) {
-		if err := s.provider.google.StopListen(); err != nil {
-			PubSubLogger.Error("failed stop listener", "message", err)
-		}
-	})
+	if len(googlePullHandlers) > 0 {
+		g.Add(func() error {
+			return s.provider.google.StartListen(googlePullHandlers)
+		}, func(err error) {
+			if err := s.provider.google.StopListen(); err != nil {
+				PubSubLogger.Error("failed stop listener", "message", err)
+			}
+		})
 
-	if err := g.Run(); err != nil {
-		PubSubLogger.Error("stop subscribe", "message", err)
+		if err := g.Run(); err != nil {
+			PubSubLogger.Error("stop subscribe", "message", err)
+		}
 	}
+
 }
 
 func (s *PubSubManager) Publish(ctx context.Context, provider PubSubProviderType, topic string, message []byte) error {
@@ -166,6 +270,7 @@ func (s *PubSubManager) Publish(ctx context.Context, provider PubSubProviderType
 // ----- Pub Sub Provider -----
 type PubSubProvider interface {
 	Publish(ctx context.Context, topic string, message []byte) error
+	CreateSubscription(SubscriberHandler) error
 	StartListen(handler []SubscriberHandler) error
 	StopListen() error
 }
@@ -199,6 +304,53 @@ func (s *GooglePubSubProvider) createClient() error {
 	return nil
 }
 
+func (s *GooglePubSubProvider) CreateSubscription(handler SubscriberHandler) error {
+	if handler.SubscriptionType() != SubscriptionTypePush {
+		return fmt.Errorf("%s is not push subscription", handler.Name())
+	}
+
+	if handler.Topic() == "" {
+		return fmt.Errorf("topic in subscription %s ir required", handler.Name())
+	}
+
+	if handler.PushEndpoint() == "" {
+		return fmt.Errorf("push endpoint in subscription %s ir required", handler.Name())
+	}
+
+	if s.Config.ServerDns == "" {
+		return errors.New("the SERVER_DSN configuration is required when using the 'push' subscription type.")
+	}
+
+	if s.Client == nil {
+		if err := s.createClient(); err != nil {
+			return err
+		}
+	}
+
+	t := s.Client.Topic(handler.Topic())
+
+	var endpoint string
+	if strings.HasPrefix("/", handler.PushEndpoint()) {
+		endpoint = fmt.Sprintf("%s/%s%s", s.Config.ServerDns, SubscriptionPrefixEndpoint, handler.PushEndpoint())
+	} else {
+		endpoint = fmt.Sprintf("%s/%s/%s", s.Config.ServerDns, SubscriptionPrefixEndpoint, handler.PushEndpoint())
+	}
+
+	_, err := s.Client.CreateSubscription(context.Background(), handler.Subscription(), pubsub.SubscriptionConfig{
+		Topic: t.GetInstance(),
+		PushConfig: pubsub.PushConfig{
+			Endpoint: endpoint,
+		},
+	})
+
+	if strings.Contains(err.Error(), "Resource already exists in the project") {
+		PubSubLogger.Info("google - subscription already exists in the project", "topic", handler.Topic(), "subscription-id", handler.Subscription())
+		return nil
+	}
+
+	return err
+}
+
 func (s *GooglePubSubProvider) StartListen(handler []SubscriberHandler) error {
 	if err := s.validate(); err != nil {
 		return err
@@ -212,7 +364,7 @@ func (s *GooglePubSubProvider) StartListen(handler []SubscriberHandler) error {
 
 	var group run.Group
 	for _, h := range handler {
-		sub := s.Client.Subscription(h.Topic())
+		sub := s.Client.Subscription(h.Subscription())
 		group.Add(s.listen(sub, h), func(err error) {})
 	}
 
@@ -238,7 +390,7 @@ func (s *GooglePubSubProvider) listen(subscription google.Subscription, handler 
 
 			// Process the received message
 			if err := handler.Consume(&subCtx, msg); err != nil {
-				PubSubLogger.Error("Failed consumer message", "topic", handler.Topic(), "message", string(msg.Data))
+				PubSubLogger.Error("Failed consumer message", "topic", handler.Subscription(), "message", string(msg.Data))
 			}
 
 			// Acknowledge the message

--- a/pubsub.go
+++ b/pubsub.go
@@ -119,20 +119,6 @@ func (s *SubscriberBase) Consume(ctx SubscriberContext, message any) error {
 	return fmt.Errorf("subscriber %s in not implemented", s.Name())
 }
 
-func (s *SubscriberBase) ParsePushSubscriptionMessage(message any) (*PushSubscriptionData, error) {
-	byteData, valid := message.([]byte)
-	if !valid {
-		return nil, errors.New("push subscription message is not valid")
-	}
-
-	var data PushSubscriptionData
-	if err := json.Unmarshal(byteData, &data); err != nil {
-		return nil, err
-	}
-
-	return &data, nil
-}
-
 // ----- Subscription Server -----
 type PubSub interface {
 	Register(handler SubscriberHandler)
@@ -230,7 +216,7 @@ func (s *PubSubManager) Serve(handler SubscriberHandler) (fasthttp.RequestHandle
 
 		response := map[string]any{"message": "success handle"}
 
-		if err := handler.Consume(&subCtx, ctx.Request.Body()); err != nil {
+		if err := handler.Consume(&subCtx, data.Message); err != nil {
 			ctx.SetStatusCode(http.StatusInternalServerError)
 			response["message"] = err.Error()
 			resByte, err := json.Marshal(response)

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -54,7 +54,7 @@ func TestNewGooglePubsub(t *testing.T) {
 
 	assert.Equal(t, true, handler.AutoAck())
 	assert.Equal(t, "unknown", handler.Name())
-	assert.Equal(t, "", handler.Topic())
+	assert.Equal(t, "", handler.Subscription())
 	assert.Error(t, handler.Consume(nil, nil))
 
 	// assert register

--- a/schedule.go
+++ b/schedule.go
@@ -42,9 +42,10 @@ type JobContext interface {
 	IsDataExist(key string) bool
 	Span() trace.Span
 	SetSpan(span trace.Span)
+	Publish(ctx context.Context, provider PubSubProviderType, topic string, message []byte) error
 }
 
-func newJobCtx(cfg *Config, jobChan chan JobParams, data JobData) JobContext {
+func newJobCtx(cfg *Config, pubsub PubSub, jobChan chan JobParams, data JobData) JobContext {
 	if data == nil {
 		data = make(JobData, 0)
 	}
@@ -53,6 +54,7 @@ func newJobCtx(cfg *Config, jobChan chan JobParams, data JobData) JobContext {
 		cfg:     cfg,
 		jobChan: jobChan,
 		data:    data,
+		pubsub:  pubsub,
 	}
 }
 
@@ -62,6 +64,7 @@ type jobContext struct {
 	jobChan chan JobParams
 	data    JobData
 	span    trace.Span
+	pubsub  PubSub
 }
 
 func (ctx *jobContext) SetContext(c context.Context) {
@@ -106,6 +109,10 @@ func (ctx *jobContext) Span() trace.Span {
 
 func (ctx *jobContext) SetSpan(span trace.Span) {
 	ctx.span = span
+}
+
+func (ctx *jobContext) Publish(c context.Context, provider PubSubProviderType, topic string, message []byte) error {
+	return ctx.pubsub.Publish(c, provider, topic, message)
 }
 
 // ----- Scheduler Base
@@ -182,11 +189,16 @@ type SchedulerServer struct {
 	Server  gocron.Scheduler
 	jobs    []Job
 	tracer  trace.Tracer
+	pubsub  PubSub
 	JobChan chan JobParams
 }
 
 func (s *SchedulerServer) SetTracer(tracer trace.Tracer) {
 	s.tracer = tracer
+}
+
+func (s *SchedulerServer) SetPubsub(pubsub PubSub) {
+	s.pubsub = pubsub
 }
 
 func (s *SchedulerServer) RegisterJob(job Job) error {
@@ -201,7 +213,7 @@ func (s *SchedulerServer) RegisterJob(job Job) error {
 			gocron.NewTask(func(scServer *SchedulerServer, jType reflect.Type) {
 				jValue := reflect.New(jType).Interface()
 				if jobValue, ok := jValue.(Job); ok {
-					jobCtx := newJobCtx(scServer.Config, scServer.JobChan, make(JobData))
+					jobCtx := newJobCtx(scServer.Config, scServer.pubsub, scServer.JobChan, make(JobData))
 					// start tracer
 					if scServer.tracer != nil {
 						spanCtx, span := scServer.tracer.Start(context.Background(), fmt.Sprintf("job - %s", jobValue.Name()))
@@ -238,7 +250,7 @@ func (s *SchedulerServer) ListenJobChan() {
 
 		if job != nil {
 			go func(server gocron.Scheduler, cfg *Config, jobChan chan JobParams, params JobParams) {
-				jobCtx := newJobCtx(s.Config, s.JobChan, make(JobData))
+				jobCtx := newJobCtx(s.Config, s.pubsub, s.JobChan, make(JobData))
 				// start tracer
 				if s.tracer != nil {
 					spanCtx, span := extractTraceJobParam(context.Background(), s.tracer, params)

--- a/schedule.go
+++ b/schedule.go
@@ -2,6 +2,7 @@ package raiden
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -203,7 +204,7 @@ func (s *SchedulerServer) SetPubsub(pubsub PubSub) {
 
 func (s *SchedulerServer) RegisterJob(job Job) error {
 	if job == nil {
-		return fmt.Errorf("Could not register nil job")
+		return errors.New("could not register empty job")
 	}
 
 	s.jobs = append(s.jobs, job)

--- a/server.go
+++ b/server.go
@@ -163,6 +163,10 @@ func (s *Server) runScheduleServer() {
 		ss.SetTracer(s.tracer)
 	}
 
+	if s.pubSub != nil {
+		ss.SetPubsub(s.pubSub)
+	}
+
 	s.SchedulerServer = ss
 
 	// register job
@@ -215,9 +219,9 @@ func (s *Server) Run() {
 		}
 	}
 
-	s.runScheduleServer()
-
 	s.runSubscriberServer()
+
+	s.runScheduleServer()
 
 	// prepare server
 	s.configureHttpServer()

--- a/server_test.go
+++ b/server_test.go
@@ -55,7 +55,7 @@ func (s *TestSubscriber) Provider() raiden.PubSubProviderType {
 	return raiden.PubSubProviderGoogle
 }
 
-func (s *TestSubscriber) Topic() string {
+func (s *TestSubscriber) Subscripbtion() string {
 	return "test.new-sub"
 }
 


### PR DESCRIPTION
## Subscription
### push subscription
- example code
```
type RideHailingPushSubscriber struct {
	raiden.SubscriberBase
}

func (s *RideHailingPushSubscriber) Name() string {
	return "RideHailingPush New"
}

func (s *RideHailingPushSubscriber) Provider() raiden.PubSubProviderType {
	return raiden.PubSubProviderGoogle
}

func (s *RideHailingPushSubscriber) Topic() string {
	return "transaction.ride-hailing.new"
}

func (s *RideHailingPushSubscriber) Subscription() string {
	return "transaction.ride-hailing.paid"
}

func (s *RideHailingPushSubscriber) SubscriptionType() raiden.SubscriptionType {
	return raiden.SubscriptionTypePush
}

func (s *RideHailingPushSubscriber) PushEndpoint() string {
	return "/transaction-ride"
}

func (s *RideHailingPushSubscriber) Consume(ctx raiden.SubscriberContext, message any) error {
	data, valid := message.(raiden.PushSubscriptionMessage)
	if !valid {
		return fmt.Errorf("subscription %s, receive invalid data", s.Name())
	}

	dByte, _ := json.MarshalIndent(data, " ", " ")
	raiden.Info("push subscription message", "data", string(dByte))
	return nil
}

```
- Example endpoint
![image](https://github.com/user-attachments/assets/547b0574-7d8c-413d-bf46-ef11d8d74527)

- Example curl call
```Curl
curl --location 'http://localhost:8002/pubsub-endpoint/transaction-ride' \
--header 'Content-Type: application/json' \
--data '{
    "message": {
        "data": "eyJpZCI6MSwibmFtZSI6IkJhc2ljIFJhaWRlbiJ9",
        "messageId": "13705223232555168",
        "message_id": "13705223232555168",
        "publishTime": "2025-01-24T10:59:59.839Z",
        "publish_time": "2025-01-24T10:59:59.839Z"
    },
    "subscription": "projects/rtk-example/subscriptions/transaction.ride-hailing.paid"
}'
```
- Example curl response
![image](https://github.com/user-attachments/assets/af026ed0-a087-41c5-b167-b39c2bd9ca95)

- Example log
![image](https://github.com/user-attachments/assets/261b781e-9aac-40f5-bec0-a1c927d22f3f)

### Use model builder in subscribers
```
type RideHailingSubscriber struct {
	raiden.SubscriberBase
}

func (s *RideHailingSubscriber) Name() string {
	return "RideHailing New"
}

func (s *RideHailingSubscriber) Provider() raiden.PubSubProviderType {
	return raiden.PubSubProviderGoogle
}

func (s *RideHailingSubscriber) Subscription() string {
	return "transaction.ride-hailing.new-sub"
}

func (s *RideHailingSubscriber) Consume(ctx raiden.SubscriberContext, message any) error {
	msg, valid := message.(*pubsub.Message)
	if !valid {
		return errors.New("invalid google pubsub message")
	}

	var book models.Book
	if err := json.Unmarshal(msg.Data, &book); err != nil {
		return err
	}

	activityEntry := new(any)
	activityLog := models.Activity{ItemId: book.Id, Activity: "create transaction at " + time.Now().String()}
	if err := db.NewQuery(nil).From(models.Activity{}).Insert(activityLog, &activityEntry); err != nil {
		raiden.Error("Insert err : ", err)
		return err
	}

	raiden.Info("activity : ", activityEntry)
	raiden.Info("ride haling new status listener executed", "data", string(msg.Data))
	return nil
}

```
## Scheduler
### Use publish in job
```
type HelloWorldJob struct {
	raiden.JobBase
}

func (j *HelloWorldJob) Name() string {
	return "hello_world_job"
}

func (j *HelloWorldJob) Before(ctx raiden.JobContext, jobID uuid.UUID, jobName string) {
	raiden.Info("before execute", "name", jobName)
}

func (j *HelloWorldJob) After(ctx raiden.JobContext, jobID uuid.UUID, jobName string) {
	raiden.Info("after execute", "name", jobName)
}

func (j *HelloWorldJob) AfterErr(ctx raiden.JobContext, jobID uuid.UUID, jobName string, err error) {
	raiden.Error("after execute with error", "message", err.Error())
}

func (j *HelloWorldJob) Duration() gocron.JobDefinition {
	return gocron.DurationJob(10 * time.Hour)
}

func (j *HelloWorldJob) Task(ctx raiden.JobContext) error {
	fmt.Printf("Hello at %s \n", time.Now().String())

	byteData, _ := json.Marshal(map[string]string{
		"message": "hello from job",
	})
	if err := ctx.Publish(context.Background(), raiden.PubSubProviderGoogle, "transaction.ride-hailing.new", byteData); err != nil {
		raiden.Error("fail publish message", err.Error())
	}

	return nil
}
```
