### PR TITLE
support http request from context

### DIFF
--- a/pkg/mock/context.go
+++ b/pkg/mock/context.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"context"
+	"time"
 
 	"github.com/sev-2/raiden"
 	"github.com/valyala/fasthttp"
@@ -29,6 +30,7 @@ type MockContext struct {
 	GetFn               func(key string) any
 	Data                map[string]any
 	PublishFn           func(ctx context.Context, provider raiden.PubSubProviderType, topic string, message []byte) error
+	HttpRequestFn       func(method string, url string, body []byte, headers map[string]string, timeout time.Duration, response any) error
 }
 
 func (c *MockContext) Ctx() context.Context {
@@ -101,4 +103,8 @@ func (c *MockContext) Set(key string, value any) {
 
 func (c *MockContext) Publish(ctx context.Context, provider raiden.PubSubProviderType, topic string, message []byte) error {
 	return c.PublishFn(ctx, provider, topic, message)
+}
+
+func (c *MockContext) HttpRequest(method string, url string, body []byte, headers map[string]string, timeout time.Duration, response any) error {
+	return c.HttpRequestFn(method, url, body, headers, timeout, response)
 }


### PR DESCRIPTION
Support Http Call in Context 

- example usage in controller 
```
func (c *HelloWorldController) Get(ctx raiden.Context) error {
	c.Result.Message = "Welcome to raiden"

	data := make(map[string]any)
	err := ctx.HttpRequest(http.MethodGet, "https://jsonplaceholder.typicode.com/todos/1", nil, nil, 10*time.Second, &data)
	if err != nil {
		return ctx.SendError(err.Error())
	}
	c.Result.Data = data

	return ctx.SendJson(c.Result)
}
```
- example usage in subscribers
```
func (s *RideHailingSubscriber) Consume(ctx raiden.SubscriberContext, message any) error {
        data := make(map[string]any)
	err := ctx.HttpRequest(http.MethodGet, "https://jsonplaceholder.typicode.com/todos/1", nil, nil, 10*time.Second, &data)
	if err != nil {
		return err
	}
	
	byteData, err := json.Marshall(data)
	if err != nil {
		return err
	}
	fmt.Println(string(byteData))
	return nil
}

```