### PR TITLE
fix: panic "reflect: NumField of non-struct type"

### DIFF
--- a/pkg/db/update.go
+++ b/pkg/db/update.go
@@ -17,7 +17,13 @@ func (q *Query) Update(p interface{}, model interface{}) error {
 	url := q.GetUrl()
 
 	var cols []string
+
 	t := reflect.TypeOf(p)
+
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
 		cols = append(cols, field.Name)

--- a/pkg/db/update_test.go
+++ b/pkg/db/update_test.go
@@ -20,4 +20,11 @@ func TestUpdate(t *testing.T) {
 		Update(article, &articleMockModel)
 
 	assert.NoError(t, err)
+
+	err = NewQuery(&mockRaidenContext).
+		Model(articleMockModel).
+		Eq("id", 1).
+		Update(&article, &articleMockModel)
+
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Description

Previously this code will generate error:

```go
db.NewQuery(ctx).Model(models.Book{}).Update(&payload, nil)

// panic: reflect: NumField of non-struct type *models.Book
```

This pull request will allow to use `.Update(&payload, nil)` or `.Update(payload, nil)`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Unit Tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
