### PR TITLE
Include HTTP response header to context

### DIFF
--- a/pkg/db/aggregate.go
+++ b/pkg/db/aggregate.go
@@ -38,16 +38,16 @@ func (q *Query) Count(opts ...CountOptions) (int, error) {
 	headers["Range-Unit"] = "items"
 
 	var a interface{}
-	resp, err := PostgrestRequest(q.Context, q.credential, fasthttp.MethodHead, url, nil, headers, q.ByPass, &a)
+	_, err := PostgrestRequest(q.Context, q.credential, fasthttp.MethodHead, url, nil, headers, q.ByPass, &a)
 	if err != nil {
 		return 0, err
 	}
 
-	contentRange := resp.Header.Peek("Content-Range")
+	contentRange := q.Context.RequestContext().Response.Header.Peek("Content-Range")
 	parts := strings.Split(string(contentRange), "/")
 
 	if len(parts) > 0 {
-		return 0, errors.New("invalid range format")
+		return 0, errors.New("invalid Content-Range format")
 	}
 
 	count, err := strconv.Atoi(parts[1])

--- a/pkg/db/postgrest_request.go
+++ b/pkg/db/postgrest_request.go
@@ -130,6 +130,14 @@ func PostgrestRequestBind(ctx raiden.Context, method string, url string, payload
 		}
 	}
 
+	for _, key := range res.Header.PeekKeys() {
+		headerKey := string(key)
+		ctx.RequestContext().Response.Header.Set(
+			headerKey,
+			string(res.Header.Peek(headerKey)),
+		)
+	}
+
 	return res, nil
 }
 


### PR DESCRIPTION
## Description

PostgREST provide the count of records on the [HTTP header](https://docs.postgrest.org/en/v12/references/api/pagination_count.html#exact-count). But, the HTTP response header disappear before return the value of `PostgrestRequestBind`. So the code below unable to get the `Content-Range` header.

Code to get the count
```go
db.NewQuery(ctx).
    From(models.Books{}).
    Count(db.CountOptions{Count: "exact"})
```

Before return from `PostgrestRequestBind`
```http
HTTP/1.1 200 OK
Server: openresty
Date: Wed, 12 Mar 2025 09:22:22 GMT
Content-Type: application/json; charset=utf-8
Connection: keep-alive
Content-Range: 0-1443/1444
Content-Location: /books
Content-Profile: public
Preference-Applied: count=exact
X-Envoy-Upstream-Service-Time: 13
X-Served-By: example.com
Connection: close
```

After return from `PostgrestRequestBind`
```http
HTTP/1.1 200 OK
Date: Wed, 12 Mar 2025 09:22:22 GMT
Content-Length: 0
```

That's happen because `fasthttp.ReleaseResponse(res)` will reset and release the response to the pool. This pull request will set the response header to the response context before disappearing.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Unit Tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
