### PR TITLE
tweak : marshall query params from controller

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -550,7 +550,11 @@ func MarshallAndValidate(ctx *fasthttp.RequestCtx, controller any) error {
 
 		// bind value to struct attribute
 		if err := setPayloadValue(payloadValue.Field(i), value); err != nil {
-			return err
+			return &ErrorResponse{
+				StatusCode: fasthttp.StatusBadRequest,
+				Code:       "invalid path or query params",
+				Message:    err.Error(),
+			}
 		}
 	}
 
@@ -559,7 +563,11 @@ func MarshallAndValidate(ctx *fasthttp.RequestCtx, controller any) error {
 	requestBody := ctx.Request.Body()
 	if requestBody != nil && string(requestBody) != "" {
 		if err := json.Unmarshal(requestBody, payloadPtr); err != nil {
-			return err
+			return &ErrorResponse{
+				StatusCode: fasthttp.StatusBadRequest,
+				Code:       "invalid request body",
+				Message:    err.Error(),
+			}
 		}
 	}
 

--- a/controller.go
+++ b/controller.go
@@ -646,9 +646,6 @@ func setNumberValue(fieldValue reflect.Value, value string) error {
 		bitSize = 32
 	case reflect.Int64:
 		bitSize = 64
-	default:
-		fieldValue.SetZero()
-		return nil
 	}
 
 	intValue, err := strconv.ParseInt(value, 10, bitSize)
@@ -672,9 +669,6 @@ func setUnsignedNumberValue(fieldValue reflect.Value, value string) error {
 		bitSize = 32
 	case reflect.Uint64:
 		bitSize = 64
-	default:
-		fieldValue.SetZero()
-		return nil
 	}
 
 	uintValue, err := strconv.ParseUint(value, 10, bitSize)

--- a/pkg/postgres/datetime_type.go
+++ b/pkg/postgres/datetime_type.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 )
@@ -54,4 +55,15 @@ func (m DateTime) MarshalJSON() ([]byte, error) {
 // String implements fmt.Stringer
 func (m DateTime) String() string {
 	return m.Time.Format(time.RFC3339)
+}
+
+func (m *DateTime) Parse(value string) error {
+	for _, format := range timeFormats {
+		t, err := time.Parse(format, value)
+		if err == nil {
+			m.Time = t
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid time format: %s", value)
 }


### PR DESCRIPTION
## Handle auto marshall query params to struct request base on attribute type : 

- [x] Byte
- [x] int, int8, int32, int64
- [x] uint, uint8, uint32, uint64  
- [x] float32, float64
- [x] pointer 
- [x] boolean   
- [x] postgres.Date
- [x] postgres.DateTime
- [x] raiden.Type

## Unit Test : 
```

type QueryParamRequest struct {
	StringValue       string         `query:"string_value"`
	BoolValue         *bool          `query:"bool_value"`
	IntValue          int            `query:"int_value"`
	Int8Value         int8           `query:"int8_value"`
	Int16Value        int16          `query:"int16_value"`
	Int32Value        int32          `query:"int32_value"`
	Int64Value        int64          `query:"int64_value"`
	Int64Ptr          *int64         `query:"int64_ptr"`
	UintValue         uint           `query:"uint_value"`
	Uint8Value        uint8          `query:"uint8_value"`
	Uint16Value       uint16         `query:"uint16_value"`
	Uint32Value       uint32         `query:"uint32_value"`
	Uint64Value       uint64         `query:"uint64_value"`
	Float32Value      *float32       `query:"float32_value"`
	Float64Value      *float64       `query:"float64_value"`
	ByteValue         byte           `query:"byte_value"`          // alias for uint8
	RuneValue         rune           `query:"rune_value"`          // alias for int32
	PostgresDateValue *postgres.Date `query:"postgres_date_value"` // optional custom date
	CustomStatusValue Status         `query:"custom_status_value"` // custom type (int/string alias)
}

type QueryParamResponse struct{}

type QueryController struct {
	raiden.ControllerBase
	Payload *QueryParamRequest
	Result  QueryParamResponse
}

func TestControllerMarshallAndValidate_QueryParams(t *testing.T) {
	// setup required data
	controller := &QueryController{}

	// setup request
	requestCtx := &fasthttp.RequestCtx{
		Request: fasthttp.Request{},
	}

	// run test 1
	q := requestCtx.Request.URI().QueryArgs()

	// Set values for all fields
	q.Set("string_value", "test string")
	q.Set("bool_value", "true")
	q.Set("int_value", "123")
	q.Set("int8_value", "8")
	q.Set("int16_value", "16")
	q.Set("int32_value", "32")
	q.Set("int64_value", "64")
	q.Set("int64_ptr", "128")
	q.Set("uint_value", "200")
	q.Set("uint8_value", "8")
	q.Set("uint16_value", "16")
	q.Set("uint32_value", "32")
	q.Set("uint64_value", "64")
	q.Set("float32_value", "3.14")
	q.Set("float64_value", "6.28")
	q.Set("byte_value", "65")   // ASCII 'A'
	q.Set("rune_value", "9731") // Unicode snowman ☃
	q.Set("postgres_date_value", "2025-05-23")
	q.Set("custom_status_value", "success")

	err := raiden.MarshallAndValidate(requestCtx, controller)
	assert.NoError(t, err)

	assert.Equal(t, "test string", controller.Payload.StringValue)
	assert.NotNil(t, controller.Payload.BoolValue)
	assert.Equal(t, true, *controller.Payload.BoolValue)
	assert.Equal(t, 123, controller.Payload.IntValue)
	assert.Equal(t, int8(8), controller.Payload.Int8Value)
	assert.Equal(t, int16(16), controller.Payload.Int16Value)
	assert.Equal(t, int32(32), controller.Payload.Int32Value)
	assert.Equal(t, int64(64), controller.Payload.Int64Value)
	assert.NotNil(t, controller.Payload.Int64Ptr)
	assert.Equal(t, int64(128), *controller.Payload.Int64Ptr)
	assert.Equal(t, uint(200), controller.Payload.UintValue)
	assert.Equal(t, uint8(8), controller.Payload.Uint8Value)
	assert.Equal(t, uint16(16), controller.Payload.Uint16Value)
	assert.Equal(t, uint32(32), controller.Payload.Uint32Value)
	assert.Equal(t, uint64(64), controller.Payload.Uint64Value)
	assert.NotNil(t, controller.Payload.Float32Value)
	assert.InDelta(t, 3.14, *controller.Payload.Float32Value, 0.001)
	assert.NotNil(t, controller.Payload.Float64Value)
	assert.InDelta(t, 6.28, *controller.Payload.Float64Value, 0.001)
	assert.Equal(t, byte(65), controller.Payload.ByteValue)
	assert.Equal(t, rune(9731), controller.Payload.RuneValue)
	assert.NotNil(t, controller.Payload.PostgresDateValue)
	assert.Equal(t, "2025-05-23", controller.Payload.PostgresDateValue.String())
	assert.Equal(t, "success", controller.Payload.CustomStatusValue.String())
}
```
## Result Unit Test
![image](https://github.com/user-attachments/assets/8749d961-a24f-47af-ba7f-7a30c915643b)
