### PR TITLE
Tweak router : controller creation

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -22,7 +22,7 @@ type (
 	Chain interface {
 		Append(middlewares ...MiddlewareFn) Chain
 		Prepend(middlewares ...MiddlewareFn) Chain
-		Then(route *Route, config *Config, tracer trace.Tracer, jobChan chan JobParams, pubSub PubSub, httpMethod string, routeType RouteType, lib map[string]any) fasthttp.RequestHandler
+		Then(route *Route, config *Config, tracer trace.Tracer, jobChan chan JobParams, pubSub PubSub, httpMethod string, lib map[string]any) fasthttp.RequestHandler
 		ServeFsHandle(cfg *Config, fsHandle fasthttp.RequestHandler) fasthttp.RequestHandler
 	}
 
@@ -74,7 +74,7 @@ func (c chain) Prepend(middlewares ...MiddlewareFn) Chain {
 // When the request comes in, it will be passed to m1, then m2, then m3
 // and finally, the given handler
 // (assuming every middleware calls the following one).
-func (c chain) Then(route *Route, config *Config, tracer trace.Tracer, jobChan chan JobParams, pubSub PubSub, httpMethod string, routeType RouteType, lib map[string]any) fasthttp.RequestHandler {
+func (c chain) Then(route *Route, config *Config, tracer trace.Tracer, jobChan chan JobParams, pubSub PubSub, httpMethod string, lib map[string]any) fasthttp.RequestHandler {
 	return func(ctx *fasthttp.RequestCtx) {
 		handler := createHandleFunc(httpMethod, route)
 		for i := range c.middlewares {

--- a/middleware.go
+++ b/middleware.go
@@ -22,7 +22,7 @@ type (
 	Chain interface {
 		Append(middlewares ...MiddlewareFn) Chain
 		Prepend(middlewares ...MiddlewareFn) Chain
-		Then(config *Config, tracer trace.Tracer, jobChan chan JobParams, pubSub PubSub, httpMethod string, routeType RouteType, fn Controller, lib map[string]any) fasthttp.RequestHandler
+		Then(route *Route, config *Config, tracer trace.Tracer, jobChan chan JobParams, pubSub PubSub, httpMethod string, routeType RouteType, lib map[string]any) fasthttp.RequestHandler
 		ServeFsHandle(cfg *Config, fsHandle fasthttp.RequestHandler) fasthttp.RequestHandler
 	}
 
@@ -74,9 +74,9 @@ func (c chain) Prepend(middlewares ...MiddlewareFn) Chain {
 // When the request comes in, it will be passed to m1, then m2, then m3
 // and finally, the given handler
 // (assuming every middleware calls the following one).
-func (c chain) Then(config *Config, tracer trace.Tracer, jobChan chan JobParams, pubSub PubSub, httpMethod string, routeType RouteType, controller Controller, lib map[string]any) fasthttp.RequestHandler {
+func (c chain) Then(route *Route, config *Config, tracer trace.Tracer, jobChan chan JobParams, pubSub PubSub, httpMethod string, routeType RouteType, lib map[string]any) fasthttp.RequestHandler {
 	return func(ctx *fasthttp.RequestCtx) {
-		handler := createHandleFunc(httpMethod, routeType, controller)
+		handler := createHandleFunc(httpMethod, route)
 		for i := range c.middlewares {
 			handler = c.middlewares[len(c.middlewares)-1-i](handler)
 		}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -36,8 +36,14 @@ func TestChain_Then(t *testing.T) {
 	// setup required data
 	controller := &HelloWorldController{}
 
+	router := raiden.Route{
+		Type:       raiden.RouteTypeCustom,
+		Controller: controller,
+		Methods:    []string{fasthttp.MethodGet},
+	}
+
 	// Call Then
-	fn := c.Then(nil, nil, nil, nil, "GET", raiden.RouteTypeCustom, controller, nil)
+	fn := c.Then(&router, nil, nil, nil, nil, "GET", nil)
 
 	// Test the returned function
 	assert.NotNil(t, fn)
@@ -52,7 +58,12 @@ func Test_Tracer(t *testing.T) {
 
 	controller := &HelloWorldController{}
 
-	fn := a.Then(nil, nil, nil, nil, "GET", raiden.RouteTypeCustom, controller, nil)
+	router := raiden.Route{
+		Controller: controller,
+		Methods:    []string{fasthttp.MethodGet},
+	}
+
+	fn := a.Then(&router, nil, nil, nil, nil, "GET", nil)
 	assert.NotNil(t, fn)
 
 	mockCtx := &mock.MockContext{

--- a/pkg/generator/apply.go
+++ b/pkg/generator/apply.go
@@ -62,8 +62,8 @@ func main() {
 			// register app resource
 			bootstrap.RegisterModels()
 			bootstrap.RegisterTypes()
-			{{if eq .Mode "bff"}}
 			bootstrap.RegisterRpc()
+			{{if eq .Mode "bff"}}
 			bootstrap.RegisterRoles()
 			bootstrap.RegisterStorages()
 			{{end}}

--- a/router.go
+++ b/router.go
@@ -212,19 +212,19 @@ func (r *router) bindRoute(chain Chain, route *Route) {
 	for _, m := range route.Methods {
 		switch strings.ToUpper(m) {
 		case fasthttp.MethodGet:
-			r.engine.GET(route.Path, chain.Then(r.config, r.tracer, r.jobChan, r.pubSub, m, route.Type, route.Controller, r.lib))
+			r.engine.GET(route.Path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, m, route.Type, r.lib))
 		case fasthttp.MethodPost:
-			r.engine.POST(route.Path, chain.Then(r.config, r.tracer, r.jobChan, r.pubSub, m, route.Type, route.Controller, r.lib))
+			r.engine.POST(route.Path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, m, route.Type, r.lib))
 		case fasthttp.MethodPut:
-			r.engine.PUT(route.Path, chain.Then(r.config, r.tracer, r.jobChan, r.pubSub, m, route.Type, route.Controller, r.lib))
+			r.engine.PUT(route.Path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, m, route.Type, r.lib))
 		case fasthttp.MethodPatch:
-			r.engine.PATCH(route.Path, chain.Then(r.config, r.tracer, r.jobChan, r.pubSub, m, route.Type, route.Controller, r.lib))
+			r.engine.PATCH(route.Path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, m, route.Type, r.lib))
 		case fasthttp.MethodDelete:
-			r.engine.DELETE(route.Path, chain.Then(r.config, r.tracer, r.jobChan, r.pubSub, m, route.Type, route.Controller, r.lib))
+			r.engine.DELETE(route.Path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, m, route.Type, r.lib))
 		case fasthttp.MethodOptions:
-			r.engine.OPTIONS(route.Path, chain.Then(r.config, r.tracer, r.jobChan, r.pubSub, m, route.Type, route.Controller, r.lib))
+			r.engine.OPTIONS(route.Path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, m, route.Type, r.lib))
 		case fasthttp.MethodHead:
-			r.engine.HEAD(route.Path, chain.Then(r.config, r.tracer, r.jobChan, r.pubSub, m, route.Type, route.Controller, r.lib))
+			r.engine.HEAD(route.Path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, m, route.Type, r.lib))
 		}
 	}
 }
@@ -256,7 +256,7 @@ func (r *router) registerRpcAndFunctionHandler(route *Route) {
 			chain = r.buildAppMiddleware(chain)
 		}
 
-		group.POST(routePath, chain.Then(r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPost, route.Type, route.Controller, r.lib))
+		group.POST(routePath, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPost, route.Type, r.lib))
 	}
 }
 
@@ -278,18 +278,12 @@ func (r *router) registerRestHandler(route *Route) {
 			chain = r.buildAppMiddleware(chain)
 		}
 
-		restController := RestController{
-			Controller: route.Controller,
-			Model:      route.Model,
-			TableName:  GetTableName(route.Model),
-		}
-
 		path := strings.TrimPrefix(route.Path, "/rest/v1")
-		group.GET(path, chain.Then(r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodGet, route.Type, restController, r.lib))
-		group.POST(path, chain.Then(r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPost, route.Type, restController, r.lib))
-		group.PUT(path, chain.Then(r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPut, route.Type, restController, r.lib))
-		group.PATCH(path, chain.Then(r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPatch, route.Type, restController, r.lib))
-		group.DELETE(path, chain.Then(r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodDelete, route.Type, restController, r.lib))
+		group.GET(path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodGet, route.Type, r.lib))
+		group.POST(path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPost, route.Type, r.lib))
+		group.PUT(path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPut, route.Type, r.lib))
+		group.PATCH(path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPatch, route.Type, r.lib))
+		group.DELETE(path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodDelete, route.Type, r.lib))
 	}
 }
 
@@ -301,18 +295,12 @@ func (r *router) registerStorageHandler(route *Route) {
 			chain = r.buildAppMiddleware(chain)
 		}
 
-		restController := StorageController{
-			Controller: route.Controller,
-			BucketName: route.Storage.Name(),
-			RoutePath:  route.Path,
-		}
-
 		path := strings.ReplaceAll(route.Path, "/storage/v1", "/storage/v1/object")
-		group.GET(path+"/{path:*}", chain.Then(r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodGet, route.Type, restController, r.lib))
-		group.POST(path+"/{path:*}", chain.Then(r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPost, route.Type, restController, r.lib))
-		group.PUT(path+"/{path:*}", chain.Then(r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPut, route.Type, restController, r.lib))
-		group.PATCH(path+"/{path:*}", chain.Then(r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPatch, route.Type, restController, r.lib))
-		group.DELETE(path+"/{path:*}", chain.Then(r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodDelete, route.Type, restController, r.lib))
+		group.GET(path+"/{path:*}", chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodGet, route.Type, r.lib))
+		group.POST(path+"/{path:*}", chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPost, route.Type, r.lib))
+		group.PUT(path+"/{path:*}", chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPut, route.Type, r.lib))
+		group.PATCH(path+"/{path:*}", chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPatch, route.Type, r.lib))
+		group.DELETE(path+"/{path:*}", chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodDelete, route.Type, r.lib))
 	}
 }
 
@@ -351,12 +339,36 @@ func createRouteGroups(engine *fs_router.Router) map[RouteType]*fs_router.Group 
 
 // The `createHandleFunc` function creates a route handler function that handles different HTTP methods
 // by calling corresponding methods on a controller object.
-func createHandleFunc(httpMethod string, routeType RouteType, c Controller) RouteHandlerFn {
+func createHandleFunc(httpMethod string, router *Route) RouteHandlerFn {
 	return func(ctx Context) error {
+
+		// ✅ Safe: created fresh per request
+		controllerType := reflect.TypeOf(router.Controller)
+		controllerValue := reflect.New(controllerType.Elem())
+		c, ok := controllerValue.Interface().(Controller)
+		if !ok {
+			return fmt.Errorf("controller must implement Controller interface")
+		}
+
+		// recreate router base on controller type
+		switch router.Type {
+		case RouteTypeRest:
+			c = RestController{
+				Controller: c,
+				Model:      router.Model,
+				TableName:  GetTableName(router.Model),
+			}
+		case RouteTypeStorage:
+			c = StorageController{
+				Controller: router.Controller,
+				BucketName: router.Storage.Name(),
+				RoutePath:  router.Path,
+			}
+		}
 
 		// marshall and validate http request data
 		// will return error if `Payload` field is not define in controller
-		if routeType != RouteTypeRest && routeType != RouteTypeStorage {
+		if router.Type != RouteTypeRest && router.Type != RouteTypeStorage {
 			if err := MarshallAndValidate(ctx.RequestContext(), c); err != nil {
 				return err
 			}

--- a/router.go
+++ b/router.go
@@ -212,19 +212,19 @@ func (r *router) bindRoute(chain Chain, route *Route) {
 	for _, m := range route.Methods {
 		switch strings.ToUpper(m) {
 		case fasthttp.MethodGet:
-			r.engine.GET(route.Path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, m, route.Type, r.lib))
+			r.engine.GET(route.Path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, m, r.lib))
 		case fasthttp.MethodPost:
-			r.engine.POST(route.Path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, m, route.Type, r.lib))
+			r.engine.POST(route.Path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, m, r.lib))
 		case fasthttp.MethodPut:
-			r.engine.PUT(route.Path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, m, route.Type, r.lib))
+			r.engine.PUT(route.Path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, m, r.lib))
 		case fasthttp.MethodPatch:
-			r.engine.PATCH(route.Path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, m, route.Type, r.lib))
+			r.engine.PATCH(route.Path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, m, r.lib))
 		case fasthttp.MethodDelete:
-			r.engine.DELETE(route.Path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, m, route.Type, r.lib))
+			r.engine.DELETE(route.Path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, m, r.lib))
 		case fasthttp.MethodOptions:
-			r.engine.OPTIONS(route.Path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, m, route.Type, r.lib))
+			r.engine.OPTIONS(route.Path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, m, r.lib))
 		case fasthttp.MethodHead:
-			r.engine.HEAD(route.Path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, m, route.Type, r.lib))
+			r.engine.HEAD(route.Path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, m, r.lib))
 		}
 	}
 }
@@ -256,7 +256,7 @@ func (r *router) registerRpcAndFunctionHandler(route *Route) {
 			chain = r.buildAppMiddleware(chain)
 		}
 
-		group.POST(routePath, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPost, route.Type, r.lib))
+		group.POST(routePath, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPost, r.lib))
 	}
 }
 
@@ -279,11 +279,11 @@ func (r *router) registerRestHandler(route *Route) {
 		}
 
 		path := strings.TrimPrefix(route.Path, "/rest/v1")
-		group.GET(path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodGet, route.Type, r.lib))
-		group.POST(path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPost, route.Type, r.lib))
-		group.PUT(path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPut, route.Type, r.lib))
-		group.PATCH(path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPatch, route.Type, r.lib))
-		group.DELETE(path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodDelete, route.Type, r.lib))
+		group.GET(path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodGet, r.lib))
+		group.POST(path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPost, r.lib))
+		group.PUT(path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPut, r.lib))
+		group.PATCH(path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPatch, r.lib))
+		group.DELETE(path, chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodDelete, r.lib))
 	}
 }
 
@@ -296,11 +296,11 @@ func (r *router) registerStorageHandler(route *Route) {
 		}
 
 		path := strings.ReplaceAll(route.Path, "/storage/v1", "/storage/v1/object")
-		group.GET(path+"/{path:*}", chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodGet, route.Type, r.lib))
-		group.POST(path+"/{path:*}", chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPost, route.Type, r.lib))
-		group.PUT(path+"/{path:*}", chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPut, route.Type, r.lib))
-		group.PATCH(path+"/{path:*}", chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPatch, route.Type, r.lib))
-		group.DELETE(path+"/{path:*}", chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodDelete, route.Type, r.lib))
+		group.GET(path+"/{path:*}", chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodGet, r.lib))
+		group.POST(path+"/{path:*}", chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPost, r.lib))
+		group.PUT(path+"/{path:*}", chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPut, r.lib))
+		group.PATCH(path+"/{path:*}", chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodPatch, r.lib))
+		group.DELETE(path+"/{path:*}", chain.Then(route, r.config, r.tracer, r.jobChan, r.pubSub, fasthttp.MethodDelete, r.lib))
 	}
 }
 

--- a/router_test.go
+++ b/router_test.go
@@ -351,37 +351,43 @@ func Test_Route(t *testing.T) {
 		},
 	}
 
-	fn := a.Then(mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "GET", raiden.RouteTypeCustom, controller, nil)
+	router := raiden.Route{
+		Type:       raiden.RouteTypeCustom,
+		Controller: controller,
+		Methods:    []string{fasthttp.MethodGet},
+	}
+
+	fn := a.Then(&router, mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "GET", nil)
 	fn(&fsCtx)
 	assert.Equal(t, "{\"message\":\"success get data\"}", string(fsCtx.Response.Body()))
 	fsCtx.Response.SetBody(nil)
 
-	fn = a.Then(mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "POST", raiden.RouteTypeCustom, controller, nil)
+	fn = a.Then(&router, mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "POST", nil)
 	fn(&fsCtx)
 	assert.Equal(t, "{\"message\":\"success post data\"}", string(fsCtx.Response.Body()))
 	fsCtx.Response.SetBody(nil)
 
-	fn = a.Then(mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "PUT", raiden.RouteTypeCustom, controller, nil)
+	fn = a.Then(&router, mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "PUT", nil)
 	fn(&fsCtx)
 	assert.Equal(t, "{\"message\":\"success put data\"}", string(fsCtx.Response.Body()))
 	fsCtx.Response.SetBody(nil)
 
-	fn = a.Then(mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "PATCH", raiden.RouteTypeCustom, controller, nil)
+	fn = a.Then(&router, mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "PATCH", nil)
 	fn(&fsCtx)
 	assert.Equal(t, "{\"message\":\"success patch data\"}", string(fsCtx.Response.Body()))
 	fsCtx.Response.SetBody(nil)
 
-	fn = a.Then(mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "DELETE", raiden.RouteTypeCustom, controller, nil)
+	fn = a.Then(&router, mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "DELETE", nil)
 	fn(&fsCtx)
 	assert.Equal(t, "{\"message\":\"success delete data\"}", string(fsCtx.Response.Body()))
 	fsCtx.Response.SetBody(nil)
 
-	fn = a.Then(mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "OPTIONS", raiden.RouteTypeCustom, controller, nil)
+	fn = a.Then(&router, mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "OPTIONS", nil)
 	fn(&fsCtx)
 	assert.Equal(t, "{\"code\":\"Not Implemented\",\"message\":\"handler not implemented\"}", string(fsCtx.Response.Body()))
 	fsCtx.Response.SetBody(nil)
 
-	fn = a.Then(mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "HEAD", raiden.RouteTypeCustom, controller, nil)
+	fn = a.Then(&router, mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "HEAD", nil)
 	fn(&fsCtx)
 	assert.Equal(t, "{\"code\":\"Not Implemented\",\"message\":\"handler not implemented\"}", string(fsCtx.Response.Body()))
 	fsCtx.Response.SetBody(nil)
@@ -406,37 +412,43 @@ func Test_RouteUnimplemented(t *testing.T) {
 		},
 	}
 
-	fn := a.Then(mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "GET", raiden.RouteTypeCustom, controller, nil)
+	router := raiden.Route{
+		Type:       raiden.RouteTypeCustom,
+		Controller: controller,
+		Methods:    []string{fasthttp.MethodGet},
+	}
+
+	fn := a.Then(&router, mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "GET", nil)
 	fn(&fsCtx)
 	assert.Equal(t, "field Payload is not exist in UnimplementedController", string(fsCtx.Response.Body()))
 	fsCtx.Response.SetBody(nil)
 
-	fn = a.Then(mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "POST", raiden.RouteTypeCustom, controller, nil)
+	fn = a.Then(&router, mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "POST", nil)
 	fn(&fsCtx)
 	assert.Equal(t, "field Payload is not exist in UnimplementedController", string(fsCtx.Response.Body()))
 	fsCtx.Response.SetBody(nil)
 
-	fn = a.Then(mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "PUT", raiden.RouteTypeCustom, controller, nil)
+	fn = a.Then(&router, mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "PUT", nil)
 	fn(&fsCtx)
 	assert.Equal(t, "field Payload is not exist in UnimplementedController", string(fsCtx.Response.Body()))
 	fsCtx.Response.SetBody(nil)
 
-	fn = a.Then(mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "PATCH", raiden.RouteTypeCustom, controller, nil)
+	fn = a.Then(&router, mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "PATCH", nil)
 	fn(&fsCtx)
 	assert.Equal(t, "field Payload is not exist in UnimplementedController", string(fsCtx.Response.Body()))
 	fsCtx.Response.SetBody(nil)
 
-	fn = a.Then(mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "DELETE", raiden.RouteTypeCustom, controller, nil)
+	fn = a.Then(&router, mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "DELETE", nil)
 	fn(&fsCtx)
 	assert.Equal(t, "field Payload is not exist in UnimplementedController", string(fsCtx.Response.Body()))
 	fsCtx.Response.SetBody(nil)
 
-	fn = a.Then(mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "OPTIONS", raiden.RouteTypeCustom, controller, nil)
+	fn = a.Then(&router, mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "OPTIONS", nil)
 	fn(&fsCtx)
 	assert.Equal(t, "field Payload is not exist in UnimplementedController", string(fsCtx.Response.Body()))
 	fsCtx.Response.SetBody(nil)
 
-	fn = a.Then(mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "HEAD", raiden.RouteTypeCustom, controller, nil)
+	fn = a.Then(&router, mockCtx.ConfigFn(), mockCtx.TracerFn(), nil, nil, "HEAD", nil)
 	fn(&fsCtx)
 	assert.Equal(t, "field Payload is not exist in UnimplementedController", string(fsCtx.Response.Body()))
 	fsCtx.Response.SetBody(nil)

--- a/router_test.go
+++ b/router_test.go
@@ -144,6 +144,7 @@ func (c *RestController) BeforeGet(ctx raiden.Context) error {
 
 type StorageController struct {
 	raiden.ControllerBase
+	Http    string `path:"/assets" type:"storage"`
 	Storage *SomeBucket
 }
 


### PR DESCRIPTION
## Tweak Router

Tweak controller instantiation in the router to ensure a fresh instance is created for each request. This prevents shared state between requests and avoids potential side effects from reusing controllers.