### PR TITLE
fix : generate rpc params body

### DIFF
--- a/rpc.go
+++ b/rpc.go
@@ -652,6 +652,10 @@ func extractRpcParam(paramType reflect.Type) (params RpcParams, err error) {
 			return params, err
 		}
 
+		if ct.Name == "" {
+			ct.Name = utils.ToSnakeCase(field.Name)
+		}
+
 		p := RpcParam{
 			Name: ct.Name,
 			Type: RpcParamDataType(ct.Type),
@@ -808,7 +812,9 @@ func ExecuteRpc(ctx Context, rpc Rpc) (any, error) {
 				if ct, err := UnmarshalRpcParamTag(columnTagStr); err == nil {
 					key = ct.Name
 				}
-			} else {
+			}
+
+			if key == "" {
 				key = utils.ToSnakeCase(fieldType.Name)
 			}
 

--- a/rpc.go
+++ b/rpc.go
@@ -801,7 +801,17 @@ func ExecuteRpc(ctx Context, rpc Rpc) (any, error) {
 	for i := 0; i < paramsType.NumField(); i++ {
 		if paramValue.IsValid() {
 			fieldType, fieldValue := paramsType.Field(i), paramValue.Field(i)
-			key := utils.SnakeCaseToPascalCase(fieldType.Name)
+
+			key := ""
+			columnTagStr := fieldType.Tag.Get("column")
+			if len(columnTagStr) >= 0 {
+				if ct, err := UnmarshalRpcParamTag(columnTagStr); err == nil {
+					key = ct.Name
+				}
+			} else {
+				key = utils.ToSnakeCase(fieldType.Name)
+			}
+
 			if rpc.UseParamPrefix() {
 				key = fmt.Sprintf("%s%s", DefaultRpcParamPrefix, key)
 			}

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -19,7 +19,7 @@ type Submission struct{}
 
 type GetSubmissionsParams struct {
 	ScouterName   string `json:"scouter_name" column:"name:scouter_name;type:varchar"`
-	CandidateName string `json:"candidate_name" column:"name:candidate_name;type:text"`
+	CandidateName string `json:"candidate_name" column:"type:text"`
 }
 type GetSubmissionsItem struct {
 	Id        int64     `json:"id" column:"name:id;type:integer"`


### PR DESCRIPTION
## Description

tweak generate param when execute rpc : 
- by default get param name from tag `column`  in `name` item
- if name not exist get name from field attribute name and convert to snake_case