### PR TITLE
fix: handle custom endpoints on multipart formdata

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -558,6 +558,13 @@ func MarshallAndValidate(ctx *fasthttp.RequestCtx, controller any) error {
 		}
 	}
 
+	// check for content type
+	// only unmarshalls type application/json or empty
+	headerContentType := ctx.Request.Header.Peek(fasthttp.HeaderContentType)
+	contentType := string(headerContentType)
+	if contentType != "" && contentType != "application/json" {
+		return nil
+	}
 	// unmarshal data from request body to payload
 	// only marshall to field with tag json
 	requestBody := ctx.Request.Body()


### PR DESCRIPTION
## Description

Handle Custom Rest endpoints to only validate and umarshall application/json payload
Feature needed to handle a multipart formdata request for a one time file uploads.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Unit Tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

![Screenshot From 2025-06-04 15-11-57](https://github.com/user-attachments/assets/070ba6c3-00fe-43c9-915c-adee26ce906d)

## Video evidence

https://jam.dev/c/73d246ad-9a9c-4d97-83c6-8ffa9d095490

## Further comments

Any Validation on mutipart formdata cannot be handled it struct and need to be handled on each custom endpoint (before post or during post)

Other content type need further testing
